### PR TITLE
fix: address critical + trivial findings from PR #1 review (subset of #3)

### DIFF
--- a/.context/state/coordination.md
+++ b/.context/state/coordination.md
@@ -50,7 +50,23 @@ Every `task_*.md` file lives in exactly one of these states. Transitions are one
 
 ## Active Locks
 
-<!-- No active locks. Add new locks here using the template above. -->
+## Lock: pr1-fix-critical-and-trivial
+**Role**: devops
+**Session**: branch `fix/pr1-critical-and-trivial`
+**Claimed At**: 2026-04-24
+**Expected Duration**: 1 session
+**Paths**:
+- `terraform/modules/kms/**`
+- `terraform/modules/cloudtrail/main.tf`
+- `terraform/govcloud/main.tf`
+- `terraform/demo/main.tf`
+- `.github/workflows/demo-plan.yml`
+- `.github/prompts/03-terraform-shared-modules.md`
+- `diagrams/network.md`
+- `.context/state/coordination.md`
+**Depends On**: PR #1 (recovery — base for branch); issue #3 (defines scope)
+**Blocks**: none
+**State**: in_progress
 
 ## Recent History
 

--- a/.github/prompts/03-terraform-shared-modules.md
+++ b/.github/prompts/03-terraform-shared-modules.md
@@ -54,16 +54,21 @@ For each module under `terraform/modules/<name>/`:
   use, deny `kms:Decrypt` outside the partition
 
 #### `cloudtrail/`
-- Multi-region trail, log-file validation enabled, KMS-encrypted, Object
-  Lock-enabled S3 bucket (governance mode, 7-year retention default)
-- Includes management + S3 data events + Lambda data events
+- Multi-region trail (where the root enables it), log-file validation
+  enabled, KMS-encrypted, Object Lock-enabled S3 bucket (governance
+  mode, 7-year retention default)
+- Management events only in the v1 module. **S3 + Lambda data events
+  are tracked as a follow-up** (see issue #3 / postmortem-001 — the
+  recovery PR scoped them out)
 - CloudWatch Logs integration with metric filters for: root login, IAM
   policy change, console without MFA, KMS key disable
 
 #### `guardduty/`
 - Detector enabled with EKS audit logs, malware protection, S3 protection,
   RDS protection (toggleable via `var.features` map for cost control)
-- Findings exported to S3 (KMS-encrypted)
+- Findings remain in GuardDuty (no S3 export wired in v1; the
+  publishing-destination resource is a follow-up if/when an S3 bucket
+  for findings is provisioned)
 
 #### `config/`
 - AWS Config recorder (all resources + global)

--- a/.github/workflows/demo-plan.yml
+++ b/.github/workflows/demo-plan.yml
@@ -20,6 +20,11 @@ jobs:
   plan:
     name: terraform plan (read-only)
     runs-on: ubuntu-latest
+    # Skip on PRs from forks: OIDC role + region secrets are not exposed to
+    # untrusted workflows, so the AWS credential step would fail with
+    # "Input required and not supplied: aws-region". Reviewers can re-run
+    # the plan locally or maintainers can run it on a sync branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     env:
       TF_IN_AUTOMATION: "true"
       TF_INPUT: "false"
@@ -54,7 +59,13 @@ jobs:
 
       - name: terraform plan
         working-directory: terraform/demo
-        run: terraform plan -no-color -out=tfplan | tee plan.txt
+        # `set -o pipefail` so a failed `terraform plan` propagates through
+        # the `tee` and fails the step. Without it, the plan exit code is
+        # masked by tee's success and the workflow proceeds to comment a
+        # truncated/empty plan as if it had succeeded.
+        run: |
+          set -o pipefail
+          terraform plan -no-color -out=tfplan | tee plan.txt
 
       - name: Upload plan artifact
         uses: actions/upload-artifact@v4

--- a/diagrams/network.md
+++ b/diagrams/network.md
@@ -132,7 +132,7 @@ flowchart LR
     Role["IAM role<br/>demo-deploy<br/>(scoped to repo + main branch)"]
     TF["terraform apply<br/>terraform/demo/"]
     AWS[("AWS commercial<br/>us-east-1")]
-    URL["Public demo URL<br/>(ALB DNS name)"]
+    URL["Public demo URL<br/>(Lambda Function URL)"]
     Cron["Nightly schedule<br/>demo-destroy.yml"]
 
     Dev -- "type DEPLOY to confirm" --> GHA

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -29,6 +29,10 @@ module "kms" {
   keys = {
     logs = {
       description = "Demo CMK for logs / CloudTrail / Lambda env vars."
+      service_principals = [
+        "cloudtrail.amazonaws.com",
+        "logs.${var.region}.amazonaws.com",
+      ]
     }
     data = {
       description = "Demo CMK for data at rest (none in this demo, but stamped for parity)."

--- a/terraform/govcloud/main.tf
+++ b/terraform/govcloud/main.tf
@@ -30,6 +30,10 @@ module "kms" {
     logs = {
       description       = "CMK for CloudTrail / CloudWatch Logs / Config delivery."
       additional_admins = var.kms_admin_principal_arns
+      service_principals = [
+        "cloudtrail.amazonaws.com",
+        "logs.${var.region}.amazonaws.com",
+      ]
     }
     data = {
       description       = "CMK for CUI data at rest (S3, EBS, RDS in workload modules)."
@@ -38,6 +42,9 @@ module "kms" {
     config = {
       description       = "CMK for AWS Config delivery channel."
       additional_admins = var.kms_admin_principal_arns
+      service_principals = [
+        "config.amazonaws.com",
+      ]
     }
   }
 }

--- a/terraform/modules/cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/main.tf
@@ -53,6 +53,12 @@ resource "aws_s3_bucket_object_lock_configuration" "trail" {
       years = var.object_lock_retention_years
     }
   }
+
+  # Object Lock requires versioning to be enabled. Terraform doesn't infer
+  # this dependency from the resource graph (both reference only the bucket),
+  # so without an explicit depends_on a fresh apply can race and fail with
+  # "Versioning must be enabled" on the Object Lock configuration.
+  depends_on = [aws_s3_bucket_versioning.trail]
 }
 
 data "aws_iam_policy_document" "trail_bucket" {

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -76,6 +76,15 @@ data "aws_iam_policy_document" "key" {
         type        = "Service"
         identifiers = each.value.service_principals
       }
+      # Scope service-principal usage to this account only. Without this,
+      # any account's CloudTrail/Config/CloudWatch Logs service could use
+      # the key if they discovered its ARN. aws:SourceAccount is the
+      # canonical scoping condition for service-principal grants.
+      condition {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+        values   = [data.aws_caller_identity.current.account_id]
+      }
     }
   }
 

--- a/terraform/modules/kms/main.tf
+++ b/terraform/modules/kms/main.tf
@@ -58,10 +58,31 @@ data "aws_iam_policy_document" "key" {
     }
   }
 
-  # Deny use outside this AWS partition. Defense-in-depth: prevents an
-  # exfiltrated key reference from being used from an unexpected partition.
+  # AWS service principals granted standard data-plane access. Required for
+  # services that perform server-side encryption against the key directly —
+  # e.g. CloudTrail, Config, CloudWatch Logs. Without this, applies that wire
+  # the key into those services succeed but the services fail at runtime.
+  dynamic "statement" {
+    for_each = length(each.value.service_principals) > 0 ? [1] : []
+    content {
+      sid    = "AllowServicePrincipalUsage"
+      effect = "Allow"
+      actions = [
+        "kms:Encrypt", "kms:Decrypt", "kms:ReEncrypt*",
+        "kms:GenerateDataKey*", "kms:DescribeKey",
+      ]
+      resources = ["*"]
+      principals {
+        type        = "Service"
+        identifiers = each.value.service_principals
+      }
+    }
+  }
+
+  # Deny use outside this AWS account. Defense-in-depth: prevents a
+  # compromised key reference from being used cross-account.
   statement {
-    sid       = "DenyOutsidePartition"
+    sid       = "DenyOutsideAccount"
     effect    = "Deny"
     actions   = ["kms:*"]
     resources = ["*"]

--- a/terraform/modules/kms/variables.tf
+++ b/terraform/modules/kms/variables.tf
@@ -10,6 +10,15 @@ variable "keys" {
     deletion_window   = optional(number, 30)
     additional_users  = optional(list(string), []) # IAM principal ARNs allowed to use the key
     additional_admins = optional(list(string), []) # IAM principal ARNs allowed to administer the key
+    # AWS service principals granted standard data-plane access
+    # (Encrypt/Decrypt/GenerateDataKey*/ReEncrypt*/DescribeKey). Required for
+    # services that perform server-side encryption against the key without
+    # going through an IAM principal — e.g. CloudTrail (`cloudtrail.amazonaws.com`),
+    # AWS Config (`config.amazonaws.com`), CloudWatch Logs
+    # (`logs.<region>.amazonaws.com`). Without this, applies that wire the key
+    # into those services will succeed but the services will fail at runtime
+    # when they try to use the key.
+    service_principals = optional(list(string), [])
   }))
   validation {
     condition     = length(var.keys) > 0


### PR DESCRIPTION
# fix: address critical + trivial findings from PR #1 review

Closes a subset of #3 — the 10 items from PR #1's review-finding index judged either **critical** (would block `terraform apply`), **trivial** (≤ a few lines, no design decisions), or **PR meta** (claim/CI hygiene). The remaining ~15 architectural items (data-events, SG egress hardening, MFA filter scope, Lambda-in-VPC, FIPS condition rewrite, the rest of the tfsec hardening backlog) stay open in #3 and will land in separate PRs so each gets its own review focus.

> **Base note:** this PR is currently based on `recovery/phases-1-7-uncommitted-work` (PR #1) because `main` doesn't have the Terraform modules being fixed yet. Once PR #1 merges, GitHub will collapse this PR's diff to just these six commits. Reviewers can also view this branch's commits independently via the per-commit links below.

## What's fixed

| ISS-NN | Source | Fix |
| --- | --- | --- |
| ISS-12 (P1) | codex | KMS key policies now grant CloudTrail / Config / CloudWatch Logs service principals the standard data-plane actions. Without this, `terraform apply` succeeds but the services fail at runtime when they try to use the key. |
| ISS-10 | copilot | Renamed `DenyOutsidePartition` SID + comment → `DenyOutsideAccount` to match the actual condition (`aws:ResourceAccount`). Doc/intent fix; no behavior change. (Bundled with ISS-12 because they edit the same statement.) |
| ISS-13 (P2) | codex | Added `depends_on = [aws_s3_bucket_versioning.trail]` to the Object Lock configuration. Object Lock requires versioning enabled; Terraform doesn't infer the dependency from the resource graph, so a fresh apply can race. |
| ISS-06, ISS-14 | copilot, codex | Added `set -o pipefail` before `terraform plan \| tee plan.txt` in `demo-plan.yml`. Without it, plan failures were masked by `tee`'s success. |
| ISS-07, ISS-16 | copilot + CI | Added `if: github.event.pull_request.head.repo.full_name == github.repository` to the demo-plan job. OIDC/region secrets aren't exposed to fork PRs, so the credential step was failing with "Input required: aws-region" (visible in PR #1's failing CI). |
| ISS-05 | copilot | Prompt 03 said `guardduty/` exports findings to S3 — module doesn't. Fixed prompt to match reality + call out the publishing-destination follow-up. |
| ISS-08 | copilot | Demo pipeline diagram said "ALB DNS name" — demo uses Lambda Function URL. Updated label. |
| ISS-11 | copilot | Prompt 03 said `cloudtrail/` includes S3 + Lambda data events — only emits management events. Updated prompt + linked the data-events follow-up to #3. |
| ISS-17, ISS-18 | CI meta | Added a proper `coordination.md` lock entry for this PR. (PR #1 didn't have one because Phases 2–7 bypassed the workflow; this PR follows the normal claim → implement → review flow.) |

## Deferred to follow-up PRs against #3

- **Architectural** (need design discussion / ADR): ISS-01 (data events), ISS-02/19 (SG egress), ISS-03 (MFA filter assumed-role), ISS-04 (Lambda in VPC), ISS-09 (FIPS condition shape), ISS-20–28 (tfsec hardening: IAM wildcards, multi-region trail, S3 access logging, CW Logs CMK, Lambda tracing).
- **CI**: ISS-15 (mermaid lint puppeteer) — pre-existing template workflow; not introduced by recovery.

## Verification

Locally, on this branch:

- `terraform fmt -recursive -check terraform/` → clean
- `terraform validate` on all 8 roots/modules → all pass
- `tflint --recursive --chdir=terraform` → clean
- `actionlint .github/workflows/demo-plan.yml` → clean
- `tfsec terraform/` → 10 unique findings; **zero new findings introduced** (all match the pre-existing list captured in #3 / PR #1 Phase 1 Index)
- `./test.sh` → 199 passed, 1 warning, 0 failed

## Doc sync

- [x] `.context/state/coordination.md` — added lock for this PR
- [ ] `AI_REPO_GUIDE.md` — no changes required (no new commands/conventions/layout)
- [x] `.github/prompts/03-terraform-shared-modules.md` — corrected module claims (ISS-05, ISS-11)
- [x] `diagrams/network.md` — corrected demo URL label (ISS-08)
- [ ] No new ADR — none of the changes alter architectural decisions

## Risk

- KMS service-principal grants on `kms:*` data-plane actions are scoped to the standard set (`Encrypt/Decrypt/GenerateDataKey*/ReEncrypt*/DescribeKey`). No `kms:*` blanket grant.
- The fork-PR guard means external contributors won't see a plan comment on their PR, only an internal-PR plan after a maintainer creates a sync branch. Acceptable trade-off; the alternative (granting fork PRs OIDC) is a security regression.

## Commits

1. `d603357` — fix(kms): service principals + DenyOutsideAccount rename
2. `5d0c6ad` — fix(cloudtrail): Object Lock depends_on
3. `bc2a175` — fix(workflows): pipefail + fork-secrets guard
4. `ee116ac` — fix(docs): prompt 03 + demo diagram
5. `0b01fe5` — state: coordination.md claim
