### PR TITLE
feat(prompt): add drive-pr-to-merge.md (closes #9)

### DIFF
--- a/.context/state/coordination.md
+++ b/.context/state/coordination.md
@@ -50,6 +50,23 @@ Every `task_*.md` file lives in exactly one of these states. Transitions are one
 
 ## Active Locks
 
+## Lock: pr-10
+<!-- managed-for-pr:10 -->
+**Role**: architect
+**Session**: feat/9-drive-pr-to-merge
+**Claimed At**: 2026-04-25T02:05:13Z
+**Expected Duration**: TBD
+**Paths**:
+- .github/copilot-instructions.md
+- .github/prompts/README.md
+- .github/prompts/drive-pr-to-merge.md
+- .github/prompts/pr-resolve-all.md
+- AGENTS.md
+- AI_REPO_GUIDE.md
+**Depends On**: none
+**Blocks**: none
+**State**: in_progress
+
 ## Lock: pr-7
 <!-- managed-for-pr:7 -->
 **Role**: backend

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -92,6 +92,11 @@ to `gh` / MCP / API.
   `.github/prompts/pr-resolve-all.md` (Phases 1–4) so the Resolution
   Report and Phase 4 thread-resolution land consistently — even when no
   `@copilot follow` mention has been posted.
+- To drive a PR end-to-end through review/resolve/merge in a single
+  invocation, follow `.github/prompts/drive-pr-to-merge.md`. It
+  composes with `pr-resolve-all.md`, uses `gh pr merge --auto` so
+  branch protection still gates the merge, and refuses to merge past
+  unresolved human review comments.
 - For bundling small follow-ups vs. splitting them, see
   `docs/guides/agent-best-practices.md` → "Issue and PR Granularity."
 - If a section the work needs is missing from a template, **update the

--- a/.github/prompts/README.md
+++ b/.github/prompts/README.md
@@ -23,10 +23,21 @@ lists come after, not before.
 ## Files here
 
 - **Shared procedural prompts** (template-provided; e.g.) — `pr-resolve-all.md`,
-  `repo-onboarding.md`, `copilot-onboarding.md`, `expand-backlog-entry.md`.
-  These describe procedures, not deliverables, and don't require pre-flight.
+  `drive-pr-to-merge.md`, `repo-onboarding.md`, `copilot-onboarding.md`,
+  `expand-backlog-entry.md`. These describe procedures, not deliverables,
+  and don't require pre-flight.
 - **Project prompts** (you add these) — `NN-<stage>.md`, one per issue.
   These require Analyst pre-flight before implementation.
+
+## Shared procedural prompts — quick reference
+
+| File | Purpose |
+|------|---------|
+| [`pr-resolve-all.md`](pr-resolve-all.md) | Resolve every issue/suggestion/TODO on a PR (Phases 1–4). Use directly when you want to address feedback without auto-merging. |
+| [`drive-pr-to-merge.md`](drive-pr-to-merge.md) | Drive a PR end-to-end: wait for bot reviews → invoke `pr-resolve-all.md` → loop → verify CI → merge under branch protection → close out. Single invocation per PR. |
+| [`repo-onboarding.md`](repo-onboarding.md) | Rebuild `AI_REPO_GUIDE.md` from real repo assets when missing or stale. |
+| [`copilot-onboarding.md`](copilot-onboarding.md) | Refresh `.github/copilot-instructions.md` after onboarding. |
+| [`expand-backlog-entry.md`](expand-backlog-entry.md) | Turn a one-line backlog entry into a fully-specified prompt + issue. |
 
 ## Project prompt series — `cmmc-level2-aws-enclave-reference`
 

--- a/.github/prompts/drive-pr-to-merge.md
+++ b/.github/prompts/drive-pr-to-merge.md
@@ -66,10 +66,15 @@ Run, in order, and abort with a single PR comment if any check fails:
 3. **Abort if** `isDraft == true` (not ready for merge).
 4. **Abort if** `isCrossRepository == true` (fork guard, Hard rule 5).
 5. **Abort if** branch protection on the base branch cannot be
-   verified — `gh api "repos/:owner/:repo/branches/<base>/protection"`
-   should return a protection object. If it 404s, post a comment
-   warning that auto-merge will not enforce gates and stop. (The
-   maintainer can re-invoke after enabling protection.)
+   verified. Derive `owner` and `repo` from
+   `gh repo view --json owner,name` (or `GITHUB_REPOSITORY`), and
+   use `baseRefName` from step 1 as `base`. Then call:
+   ```
+   gh api "repos/$owner/$repo/branches/$base/protection"
+   ```
+   If it 404s, post a comment warning that auto-merge will not
+   enforce gates and stop. (The maintainer can re-invoke after
+   enabling protection.)
 
 If all checks pass, post a one-line "🚀 Driving PR #N to merge" comment
 and continue.
@@ -79,15 +84,23 @@ and continue.
 The goal is **quiescence**: no new bot review activity for a bounded
 window, AND at least one bot has reviewed the latest commit.
 
-**Bot allow-list** (mirrors `pr-resolve-all.md` Phase 4):
-- `copilot-pull-request-reviewer[bot]`
-- `gemini-code-assist[bot]`
-- `chatgpt-codex-connector[bot]`
-- `copilot-swe-agent[bot]` (relay-only)
-- Any additional bot identity already covered by
-  `.github/workflows/agent-relay-reviews.yml`.
+**Bot allow-list** (must match `pr-resolve-all.md` Phase 4):
+- Normalize reviewer identities before comparison by stripping any
+  trailing `[bot]` suffix (if present) and comparing
+  case-insensitively against the following normalized list:
+  - `gemini-code-assist`
+  - `copilot-pull-request-reviewer`
+  - `copilot`
+  - `chatgpt-codex-connector`
+  - `codex`
+  - `claude`
+  - `copilot-swe-agent` (relay-only)
+- Apply the same normalization rule as `pr-resolve-all.md` Phase 4:
+  a REST-returned `gemini-code-assist[bot]` → strip `[bot]` →
+  `gemini-code-assist` → lowercase → match ✅. Treat any raw GitHub
+  login that normalizes to one of the above values as allow-listed.
 
-**Polling pattern** (use `gh pr view <n> --json reviews,comments`):
+**Polling pattern** (use `gh pr view <n> --json headRefOid,reviews,comments`):
 
 1. Record `headRefOid` (the latest commit SHA).
 2. Track the timestamp of the most recent bot review or bot review
@@ -123,8 +136,9 @@ This relies on the "Stable contract for callers" section in
 
 **Caller success for this cycle** (per the contract):
 - Every `ISS-NN` in the Phase 3 status table is `✅ Fixed`,
-  `🔁 Already resolved`, `⏭️ Deferred`, or `❌ Won't fix`. Any
-  `❓ Cannot reproduce` triggers escalation, not retry.
+  `✅ Already resolved`, `❌ Not reproducible`, or `❌ Out of scope`.
+  Any `⚠️ Needs clarification` or `⚠️ Partial fix` triggers
+  escalation, not retry.
 - Every Phase 4 row is `✅ Resolved`, `⏭️ Skipped`, `🚫 Refused
   (human-authored)`, or `⚠️ Errored` (the relay-fallback workflow
   will retry errored rows).
@@ -167,24 +181,37 @@ naming the slow check.
 
 ## Phase 4.5 — Human-comment guard (Hard rule 4)
 
-Enumerate review threads on the PR:
+Enumerate **all** review threads on the PR by paginating until
+`hasNextPage` is false. Derive `$owner` and `$repo` from
+`gh repo view --json owner,name` (same values obtained in Phase 0).
 
 ```bash
-gh api graphql -f query='
-  query($n: Int!) {
-    repository(owner:"...", name:"...") {
-      pullRequest(number: $n) {
-        reviewThreads(first: 100) {
-          nodes {
-            id
-            isResolved
-            comments(first: 1) { nodes { author { login } } }
+# Paginate reviewThreads; repeat with $after until hasNextPage == false
+gh api graphql \
+  -F owner="$owner" -F repo="$repo" -F n=<n> -F after="$cursor" \
+  -f query='
+    query($owner: String!, $repo: String!, $n: Int!, $after: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $n) {
+          reviewThreads(first: 100, after: $after) {
+            nodes {
+              id
+              isResolved
+              comments(first: 1) { nodes { author { login } } }
+            }
+            pageInfo { hasNextPage endCursor }
           }
         }
       }
-    }
-  }' -F n=<n>
+    }'
 ```
+
+On the first call omit `$after` (or pass an empty string). After each
+page, check `reviewThreads.pageInfo.hasNextPage`. If `true`, set
+`$cursor` to `reviewThreads.pageInfo.endCursor` and repeat. Collect
+all `nodes` across pages before making the merge/abort decision below.
+Failing to paginate can miss unresolved human threads beyond page 100
+and would violate Hard rule 4.
 
 For each thread where `isResolved == false`:
 - If the root comment author is in the bot allow-list (Phase 1) and
@@ -205,12 +232,21 @@ Notes:
   preserving branch protection. **Do not** use `--merge` without
   `--auto` — that would bypass gates if checks haven't completed.
 - `--delete-branch` removes the head branch on merge.
-- If `--auto` is rejected (e.g. status checks already complete),
-  fall back to `gh pr merge <n> --squash --delete-branch` —
-  branch protection still gates this; the only difference is timing.
+- If `--auto` is rejected because auto-merge is unnecessary (for
+  example, required checks are already complete and GitHub reports
+  the PR is mergeable now), you may fall back to
+  `gh pr merge <n> --squash --delete-branch` **only after**
+  explicitly verifying **all** of the following are already true:
+  - required status checks are complete and passing (Phase 4 green);
+  - required approvals are present;
+  - unresolved human review threads are zero (Phase 4.5 cleared); and
+  - GitHub reports `mergeableState` is not `BLOCKED`, `CONFLICTING`,
+    or any other non-ready state.
+  If any of those cannot be confirmed, do **not** use the fallback —
+  abort and report what is still blocking merge.
 
 If the merge command errors:
-- `mergeable_state == blocked` — abort and report the blocker.
+- `mergeableState == BLOCKED` — abort and report the blocker.
 - Permission errors — abort and request human intervention.
 - Anything else — abort, do not retry blindly.
 

--- a/.github/prompts/drive-pr-to-merge.md
+++ b/.github/prompts/drive-pr-to-merge.md
@@ -188,7 +188,7 @@ Enumerate **all** review threads on the PR by paginating until
 ```bash
 # Paginate reviewThreads; repeat with $after until hasNextPage == false
 gh api graphql \
-  -F owner="$owner" -F repo="$repo" -F n=<n> -F after="$cursor" \
+  -F owner="$owner" -F repo="$repo" -F n="$n" -F after="$cursor" \
   -f query='
     query($owner: String!, $repo: String!, $n: Int!, $after: String) {
       repository(owner: $owner, name: $repo) {
@@ -206,7 +206,7 @@ gh api graphql \
     }'
 ```
 
-On the first call omit `$after` (or pass an empty string). After each
+Initialize `$cursor` to an empty string before the first call (`cursor=""`); the `-F after="$cursor"` flag is always included — GitHub GraphQL treats an empty string as "no cursor" for the first page. After each
 page, check `reviewThreads.pageInfo.hasNextPage`. If `true`, set
 `$cursor` to `reviewThreads.pageInfo.endCursor` and repeat. Collect
 all `nodes` across pages before making the merge/abort decision below.

--- a/.github/prompts/drive-pr-to-merge.md
+++ b/.github/prompts/drive-pr-to-merge.md
@@ -1,0 +1,269 @@
+# Drive PR to Merge — Single-invocation review/resolve/merge driver
+
+> **Usage**: Post one of these as a PR comment:
+>   - `@claude follow .github/prompts/drive-pr-to-merge.md`
+>   - `@copilot follow .github/prompts/drive-pr-to-merge.md`
+>
+> The agent will execute Phases 0–6 below to drive the PR end-to-end:
+> wait for bot reviews → resolve them via `pr-resolve-all.md` → loop
+> until quiescent → verify CI → merge under branch protection →
+> close out. **You invoke this once per PR.**
+>
+> This prompt **composes with** `.github/prompts/pr-resolve-all.md`
+> (Phase 2 below delegates to it). It does **not** duplicate that
+> procedure. The contract between the two prompts is the
+> "Stable contract for callers" section in `pr-resolve-all.md` —
+> see that section before changing either file.
+
+---
+
+## When to use this
+
+- You authored or rebased a PR and want it driven to merge after bot review.
+- The PR is ready: passes local verification, has no known blockers,
+  and you've already added any human reviewers you want on it.
+- Branch protection on the target branch is configured (this prompt
+  uses `gh pr merge --auto`, which **requires** branch protection to
+  enforce CI/approval gates).
+
+## When NOT to use this
+
+- The PR has open human review comments — this prompt explicitly
+  refuses to merge in that case (Phase 4.5).
+- The PR is a draft.
+- The PR head is from a fork — the merge step uses tokens that must
+  not be exposed on cross-repo PRs.
+- You want to inspect the resolve step's output before merging — use
+  `pr-resolve-all.md` directly instead.
+
+## Hard rules (apply to every phase)
+
+1. **Never bypass branch protection.** Use `gh pr merge --auto` so
+   protected-branch checks still gate the merge.
+2. **Never use `--no-verify`** on git operations.
+3. **Never resolve human-authored review threads.** Phase 4 of
+   `pr-resolve-all.md` is allow-listed to bot identities only;
+   re-using its allow-list here is mandatory.
+4. **Never merge a PR that has unresolved human review comments.**
+   Phase 4.5 below enforces this.
+5. **Fork guard**: refuse to operate on cross-repository PRs.
+   Run `gh pr view <n> --json isCrossRepository` and abort if true.
+6. **Loop bound**: maximum 3 resolve cycles per PR. If the same set of
+   findings appears twice in a row, abort and post an escalation
+   comment instead of looping further.
+7. **Idempotency**: re-invoking this prompt on an already-merged PR
+   must detect that in Phase 0 and exit cleanly.
+
+---
+
+## Phase 0 — Preconditions
+
+Run, in order, and abort with a single PR comment if any check fails:
+
+1. `gh pr view <n> --json state,isDraft,isCrossRepository,mergeable,baseRefName,headRefName,labels`
+2. **Abort if** `state != "OPEN"` (already merged or closed — exit
+   cleanly, this is the idempotency contract).
+3. **Abort if** `isDraft == true` (not ready for merge).
+4. **Abort if** `isCrossRepository == true` (fork guard, Hard rule 5).
+5. **Abort if** branch protection on the base branch cannot be
+   verified — `gh api "repos/:owner/:repo/branches/<base>/protection"`
+   should return a protection object. If it 404s, post a comment
+   warning that auto-merge will not enforce gates and stop. (The
+   maintainer can re-invoke after enabling protection.)
+
+If all checks pass, post a one-line "🚀 Driving PR #N to merge" comment
+and continue.
+
+## Phase 1 — Wait for bot reviews
+
+The goal is **quiescence**: no new bot review activity for a bounded
+window, AND at least one bot has reviewed the latest commit.
+
+**Bot allow-list** (mirrors `pr-resolve-all.md` Phase 4):
+- `copilot-pull-request-reviewer[bot]`
+- `gemini-code-assist[bot]`
+- `chatgpt-codex-connector[bot]`
+- `copilot-swe-agent[bot]` (relay-only)
+- Any additional bot identity already covered by
+  `.github/workflows/agent-relay-reviews.yml`.
+
+**Polling pattern** (use `gh pr view <n> --json reviews,comments`):
+
+1. Record `headRefOid` (the latest commit SHA).
+2. Track the timestamp of the most recent bot review or bot review
+   comment that references `headRefOid`.
+3. Quiescence is reached when **both**:
+   - At least one allow-listed bot has reviewed the current
+     `headRefOid`, AND
+   - No new bot review or comment has appeared in the last 5 minutes.
+4. Hard timeout: **15 minutes** total wall-clock time in Phase 1.
+   - If at timeout there is at least one bot review on the current
+     SHA, proceed to Phase 2 with what's there.
+   - If at timeout there is **zero** bot review on the current SHA,
+     post an escalation comment explaining no bot reviewed within
+     15 minutes and stop. Do **not** merge a PR with no bot review.
+
+Polling cadence: every 60 seconds. Do not busy-loop.
+
+## Phase 2 — Resolve via `pr-resolve-all.md`
+
+Delegate to the canonical resolve procedure:
+
+> **Action**: Execute `.github/prompts/pr-resolve-all.md` Phases 1–4
+> against the current PR. Capture the resulting Resolution Report
+> comment.
+
+This relies on the "Stable contract for callers" section in
+`pr-resolve-all.md`. Specifically, after Phase 2 completes:
+
+- Read the most recent comment with the heading
+  `## Resolution Report` posted by the agent.
+- Inside it, locate the `### Phase 4 — Thread auto-resolution`
+  sub-section.
+
+**Caller success for this cycle** (per the contract):
+- Every `ISS-NN` in the Phase 3 status table is `✅ Fixed`,
+  `🔁 Already resolved`, `⏭️ Deferred`, or `❌ Won't fix`. Any
+  `❓ Cannot reproduce` triggers escalation, not retry.
+- Every Phase 4 row is `✅ Resolved`, `⏭️ Skipped`, `🚫 Refused
+  (human-authored)`, or `⚠️ Errored` (the relay-fallback workflow
+  will retry errored rows).
+
+If the cycle is not successful, abort with an escalation comment
+listing the failing rows. Do not merge.
+
+## Phase 3 — Re-check loop
+
+After Phase 2 commits land, bots will often review again. Loop:
+
+```text
+cycle = 1
+while cycle <= 3:
+    re-run Phase 1 (wait for bot reviews on the new headRefOid)
+    if no new actionable findings since last cycle:
+        break    # quiescent, proceed to Phase 4
+    if findings == previous cycle findings:
+        # same findings twice in a row = stuck
+        abort with escalation comment
+    re-run Phase 2 (pr-resolve-all)
+    cycle += 1
+
+if cycle > 3:
+    abort with escalation comment
+```
+
+The cycle counter is the same one tracked in `pr-resolve-all.md`'s
+relay-comment fingerprint header (`cycle N/3`).
+
+## Phase 4 — CI verification
+
+Run `gh pr checks <n>`. All required status checks must be `pass`,
+`success`, or `neutral`. Any `failure` or `error` aborts with an
+escalation comment.
+
+If any check is still `pending` or `in_progress`, wait up to 10
+minutes (poll every 60 s). Past 10 minutes, abort with a comment
+naming the slow check.
+
+## Phase 4.5 — Human-comment guard (Hard rule 4)
+
+Enumerate review threads on the PR:
+
+```bash
+gh api graphql -f query='
+  query($n: Int!) {
+    repository(owner:"...", name:"...") {
+      pullRequest(number: $n) {
+        reviewThreads(first: 100) {
+          nodes {
+            id
+            isResolved
+            comments(first: 1) { nodes { author { login } } }
+          }
+        }
+      }
+    }
+  }' -F n=<n>
+```
+
+For each thread where `isResolved == false`:
+- If the root comment author is in the bot allow-list (Phase 1) and
+  Phase 4 marked it `✅ Resolved`, that's fine — it's the auto-resolve
+  result.
+- If the root comment author is **not** in the bot allow-list, that's
+  a human-authored unresolved thread. **Abort.** Post an escalation
+  comment listing the unresolved human threads and stop.
+
+## Phase 5 — Merge
+
+```bash
+gh pr merge <n> --squash --auto --delete-branch
+```
+
+Notes:
+- `--auto` means GitHub waits for required checks before merging,
+  preserving branch protection. **Do not** use `--merge` without
+  `--auto` — that would bypass gates if checks haven't completed.
+- `--delete-branch` removes the head branch on merge.
+- If `--auto` is rejected (e.g. status checks already complete),
+  fall back to `gh pr merge <n> --squash --delete-branch` —
+  branch protection still gates this; the only difference is timing.
+
+If the merge command errors:
+- `mergeable_state == blocked` — abort and report the blocker.
+- Permission errors — abort and request human intervention.
+- Anything else — abort, do not retry blindly.
+
+## Phase 6 — Post-merge cleanup
+
+After merge succeeds:
+
+1. Post a final PR comment summarizing what shipped:
+   - Issues closed.
+   - Cycle count used.
+   - Any deferred items.
+2. Update `.context/sessions/latest_summary.md` per the AGENTS.md
+   close-out cadence (3–5 line entry: what shipped, what was harder
+   than expected, what generalizes).
+3. If there were deferred items, file follow-up issues.
+
+---
+
+## Worked example
+
+Maintainer comments on PR #42:
+
+> `@copilot follow .github/prompts/drive-pr-to-merge.md`
+
+Agent:
+1. Phase 0: PR is open, not draft, not a fork, base branch is
+   protected. ✅ Posts "🚀 Driving PR #42 to merge".
+2. Phase 1: Polls for 4 minutes, sees gemini + copilot reviews on
+   the current SHA, no new activity in 5 minutes. ✅ Quiescent.
+3. Phase 2: Invokes `pr-resolve-all.md`. Posts the Index, fixes
+   3 findings, posts the Resolution Report with all 3 ISS rows
+   `✅ Fixed` and 3 Phase 4 rows `✅ Resolved`. ✅ Cycle 1 success.
+4. Phase 3: Bots review the fix commit. One new gemini comment
+   appears (medium severity). Cycle 2 runs `pr-resolve-all` again,
+   fixes it, all green. ✅ Cycle 2 success. No new findings → exit
+   loop.
+5. Phase 4: All 12 required checks `pass`.
+6. Phase 4.5: Zero unresolved human threads.
+7. Phase 5: `gh pr merge 42 --squash --auto --delete-branch` →
+   merged, branch deleted.
+8. Phase 6: Posts close-out comment, updates
+   `.context/sessions/latest_summary.md`.
+
+---
+
+## Anti-patterns (don't do these)
+
+- **Don't fold `pr-resolve-all.md` into this file.** Composition
+  is intentional. See the issue #9 plan refinement.
+- **Don't bypass Phase 4.5.** A human review comment is a stop sign,
+  not a hint.
+- **Don't use `--merge` or `--rebase` without `--auto`** unless you
+  have explicitly verified all required checks are already green.
+- **Don't loop past cycle 3.** Escalate to a human instead.
+- **Don't disable branch protection to "make the merge easier."**
+  If branch protection is missing, fix that in a separate PR first.

--- a/.github/prompts/pr-resolve-all.md
+++ b/.github/prompts/pr-resolve-all.md
@@ -32,6 +32,56 @@ You are resolving every open issue, suggestion, and TODO in this pull request. Y
 > `Part 2/N`, … comments rather than truncating. Apply the Rules section to
 > every phase.
 
+## Stable contract for callers
+
+This prompt is invoked directly by humans/agents AND composed into other
+prompts (notably `.github/prompts/drive-pr-to-merge.md`). The following
+anchors are stable and **MUST** be preserved across edits to this file
+so callers can detect success/failure without re-reading the whole
+procedure each time.
+
+If you change any of these, bump the version below and update every
+caller in the same PR.
+
+**Contract version**: `1.0`
+
+**A. Phase 1 Index comment**
+- Posted as a standalone PR comment before any fix commits.
+- Heading: `## Issue/Suggestion Index`.
+- Each row has a sequential `ISS-NN` ID.
+
+**B. Phase 3 Resolution Report comment**
+- Heading: `## Resolution Report` (followed by the Phase 3 sections in
+  the example block in this file).
+- Includes a per-item status table where every `ISS-NN` has one of the
+  statuses defined in Phase 2 Step 5 (`✅ Fixed`, `❌ Won't fix`,
+  `⏭️ Deferred`, `🔁 Already resolved`, `❓ Cannot reproduce`).
+
+**C. Phase 4 Thread auto-resolution table**
+- Sub-heading inside the Phase 3 comment:
+  `### Phase 4 — Thread auto-resolution`.
+- Markdown table with **at minimum** these columns, in this order:
+  `Thread | Thread ID | ISS | Author | Action | Notes`.
+- `Action` column values are one of: `✅ Resolved`, `⚠️ Errored`,
+  `⏭️ Skipped`, `🚫 Refused (human-authored)`.
+- `Thread ID` is the GraphQL node ID (`PRRT_…`).
+
+**D. Caller success criteria**
+A caller (e.g. `drive-pr-to-merge.md`) treats this prompt as
+**successful for one cycle** when **both**:
+1. Every `ISS-NN` in the Phase 3 status table has a non-failing
+   status (`✅ Fixed`, `🔁 Already resolved`, or a documented
+   `⏭️ Deferred` / `❌ Won't fix`).
+2. Every Phase 4 row is `✅ Resolved`, `⏭️ Skipped`, or
+   `🚫 Refused (human-authored)`. `⚠️ Errored` rows are
+   acceptable only if the caller knows the relay-fallback workflow
+   will retry them (see ADR-008).
+
+**E. Cycle counter**
+The relay-comment fingerprint header carries the cycle number:
+`📋 **Review Relay (cycle N/3)**`. Maximum 3 cycles per PR; cycle 4+
+is an abort signal for callers.
+
 ## Phase 1: Build the Issue/Suggestion Index
 
 Scan ALL of these sources for issues, suggestions, requested changes, and TODOs:

--- a/.github/prompts/pr-resolve-all.md
+++ b/.github/prompts/pr-resolve-all.md
@@ -54,8 +54,9 @@ caller in the same PR.
 - Heading: `## Resolution Report` (followed by the Phase 3 sections in
   the example block in this file).
 - Includes a per-item status table where every `ISS-NN` has one of the
-  statuses defined in Phase 2 Step 5 (`✅ Fixed`, `❌ Won't fix`,
-  `⏭️ Deferred`, `🔁 Already resolved`, `❓ Cannot reproduce`).
+  statuses defined in Phase 2 Step 5: `✅ Fixed`, `✅ Already resolved`,
+  `⚠️ Needs clarification`, `⚠️ Partial fix`, `❌ Not reproducible`,
+  `❌ Out of scope`.
 
 **C. Phase 4 Thread auto-resolution table**
 - Sub-heading inside the Phase 3 comment:

--- a/.github/prompts/pr-resolve-all.md
+++ b/.github/prompts/pr-resolve-all.md
@@ -71,8 +71,10 @@ caller in the same PR.
 A caller (e.g. `drive-pr-to-merge.md`) treats this prompt as
 **successful for one cycle** when **both**:
 1. Every `ISS-NN` in the Phase 3 status table has a non-failing
-   status (`✅ Fixed`, `🔁 Already resolved`, or a documented
-   `⏭️ Deferred` / `❌ Won't fix`).
+   status (`✅ Fixed`, `✅ Already resolved`, `❌ Not reproducible`,
+   or a documented `❌ Out of scope`). `⚠️ Needs clarification` and
+   `⚠️ Partial fix` are escalation signals — the caller must abort
+   the merge cycle, not retry.
 2. Every Phase 4 row is `✅ Resolved`, `⏭️ Skipped`, or
    `🚫 Refused (human-authored)`. `⚠️ Errored` rows are
    acceptable only if the caller knows the relay-fallback workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ GitHub auto-populates issue and PR templates only in the browser flow, not when 
 - **Creating issues programmatically** — use the body skeleton from the matching `.github/ISSUE_TEMPLATE/{feature_request,bug_report,agent_init}.md` file (Markdown body only; strip the leading YAML front-matter).
 - **Creating PRs programmatically** — use the body skeleton from `.github/pull_request_template.md` (no front-matter to strip in this file). The **Doc sync** checklist is REQUIRED; Judge enforces it at diff-gate.
 - **Addressing review feedback on a PR you authored** — follow `.github/prompts/pr-resolve-all.md` (Phases 1–4) so the Resolution Report and Phase 4 thread-resolution land consistently. This applies even when no `@<agent> follow` mention has been posted; ad-hoc fixes skip the audit trail.
+- **Driving a PR end-to-end through review/resolve/merge** — invoke `.github/prompts/drive-pr-to-merge.md` once per PR. It composes with `pr-resolve-all.md`, enforces branch protection via `gh pr merge --auto`, and refuses to merge past unresolved human review comments. See that file's Hard rules.
 - **Bundling small follow-ups vs. splitting** — see `docs/guides/agent-best-practices.md` → "Issue and PR Granularity."
 - If a section the work needs is missing from a template, **update the template in the same PR** rather than skipping the section.
 

--- a/AI_REPO_GUIDE.md
+++ b/AI_REPO_GUIDE.md
@@ -90,6 +90,10 @@ demo. Ships:
   (`.github/prompts/NN-*.md`) must have a passing Pre-Flight Report
   before implementation begins. See [`AGENTS.md`](AGENTS.md) → "Analyst
   pre-flight gate".
+- **Driving a PR to merge**: invoke
+  [`.github/prompts/drive-pr-to-merge.md`](.github/prompts/drive-pr-to-merge.md)
+  once per PR to wait for bot reviews, resolve them via
+  `pr-resolve-all.md`, verify CI, and merge under branch protection.
 - **Terraform conventions** (once `terraform/` lands): partition-aware via
   `data.aws_partition.current` (no hardcoded `arn:aws:` strings); pinned
   `terraform >= 1.6`, `aws >= 5.40`; `terraform fmt -recursive` clean.


### PR DESCRIPTION
## Summary

New shared procedural prompt — `.github/prompts/drive-pr-to-merge.md` — that drives a PR end-to-end through review → resolve → CI → merge in a single invocation. Closes #9.

Composes with `.github/prompts/pr-resolve-all.md` (Phase 2 below delegates to it). Does **not** duplicate it. The contract between the two prompts is locked via a new "Stable contract for callers" section in `pr-resolve-all.md`.

## Why a new prompt instead of an AGENTS.md instruction

Discussed on issue #9 and in the chat that produced it: a universal "monitor and merge all PRs" instruction in AGENTS.md would be unreliable (agents are turn-based, not daemons), would conflate roles, and would remove the merge gate that ADR-006 deliberately put in place. A targeted, opt-in prompt file is the right scope.

## Phases (drive-pr-to-merge.md)

| Phase | Purpose | Abort condition |
|---|---|---|
| 0 | Preconditions | not open / draft / fork / base branch unprotected |
| 1 | Wait for bot reviews to quiesce | 5-min idle + ≥1 bot review on current SHA, 15-min cap |
| 2 | Invoke `pr-resolve-all.md` Phases 1–4 | Phase 3 status table or Phase 4 table contains failing rows |
| 3 | Re-check loop | max 3 cycles; same findings twice = abort |
| 4 | CI verification | any required check fails or stays pending past 10 min |
| 4.5 | Human-comment guard | any human-authored unresolved review thread |
| 5 | Merge via `gh pr merge --squash --auto --delete-branch` | mergeable_state blocked, permission errors |
| 6 | Post-merge close-out | n/a |

## Hard rules (embedded in the prompt)

1. Never bypass branch protection — `--auto` always.
2. Never `--no-verify`.
3. Never resolve human-authored review threads.
4. Never merge a PR with unresolved human review comments.
5. Fork guard: refuse on cross-repository PRs.
6. Max 3 resolve cycles.
7. Idempotent on already-merged PRs.

## Stable contract additions to `pr-resolve-all.md`

New section near the top (before Phase 1) called "Stable contract for callers", contract version `1.0`. Locks:

- Phase 1 Index comment heading: `## Issue/Suggestion Index`
- Phase 3 Resolution Report heading: `## Resolution Report`
- Phase 4 table columns: `Thread | Thread ID | ISS | Author | Action | Notes`
- Action enum: `✅ Resolved`, `⚠️ Errored`, `⏭️ Skipped`, `🚫 Refused (human-authored)`
- Caller success criteria
- Cycle counter format

Future edits to `pr-resolve-all.md` must preserve these anchors or bump the contract version and update every caller in the same PR.

## Doc sync

- [x] `.github/prompts/README.md` — new "Shared procedural prompts — quick reference" table
- [x] `AGENTS.md` — single-line cross-reference under "Templates and conventions"
- [x] `.github/copilot-instructions.md` — same single-line cross-reference (mirrors AGENTS.md)
- [x] `AI_REPO_GUIDE.md` — new "Driving a PR to merge" bullet
- [x] No ADR needed — composes with existing ADR-006 (auto-merge opt-in), ADR-007 (auto-resolve threads), ADR-008 (Copilot fallback). The prompt explicitly relies on those decisions.
- [x] No tests added — pure prompt/doc PR. End-to-end verification will happen by invoking the prompt on the next backlog PR.

## Verification

```
./test.sh
# Passed: 199 / Warnings: 1 / Failed: 0
# Template verification PASSED with warnings
```

No source/terraform changes — text-only PR.

## Anti-patterns (also documented in the prompt)

- Folding `pr-resolve-all.md` into this file via cherry-pick is **explicitly rejected**. Composition keeps each file focused and avoids ~600 lines of duplicated contract surface.
- The merge driver does not weaken any merge gate — branch protection is mandatory, and Phase 5 uses `--auto` to enforce it.

## Closes

Closes #9.
