### PR TITLE
relay(phase4): switch fallback trigger from issue_comment to label (closes #8)

### DIFF
--- a/.github/prompts/pr-resolve-all.md
+++ b/.github/prompts/pr-resolve-all.md
@@ -310,6 +310,14 @@ Because Phase 4 runs **before** Phase 3 posts the Resolution Report (see "How to
 
 Use `⚠️ Errored` when the per-thread gate passed but the GraphQL mutation failed (e.g. `FORBIDDEN`). On the Copilot path, the relay-fallback job will pick up `⚠️ Errored` rows by Thread ID, post the audit reply under `CLAUDE_PAT`, and fire `resolveReviewThread`. Use `⏭️ Skipped` only when the per-thread gate failed (human author, status not `✅ Fixed`, etc.) — that signals the fallback to leave the thread alone.
 
+**If at least one row is `⚠️ Errored`** (which is the normal Copilot-path outcome — its cloud-agent token cannot complete the mutations), add the trigger label that fires the fallback workflow. Do this **after** posting the Phase 3 Resolution Report (so the report is in place when the fallback scans for it):
+
+```bash
+gh pr edit <pr_number> --add-label phase4-needs-fallback
+```
+
+The `phase4-fallback` job in `.github/workflows/agent-relay-reviews.yml` consumes the label, retries the mutations under `CLAUDE_PAT`, and removes the label on success. Skip this step if every Phase 4 row is `✅ Resolved`, `⏭️ Skipped`, or `🚫 Refused (human-authored)` — there is no work for the fallback. See ADR-008 for why the trigger is a label rather than the Phase 3 comment itself.
+
 ### Safety rules
 
 - **Never resolve a human-authored thread**, even if you fixed what they asked for. Humans expect to click Resolve themselves.

--- a/.github/prompts/pr-resolve-all.md
+++ b/.github/prompts/pr-resolve-all.md
@@ -26,7 +26,9 @@ You are resolving every open issue, suggestion, and TODO in this pull request. Y
 
 > **How to run this prompt**: Read this entire file before starting. Execute
 > Phase 1, then Phase 2. Execute Phase 4 **before** posting the Phase 3
-> Resolution Report so Phase 3 can include the Phase 4 results. Do not
+> Resolution Report so Phase 3 can include the Phase 4 results. After
+> Phase 3 is posted, execute Phase 5 (Copilot path only) to trigger
+> the fallback workflow if any Phase 4 row was `⚠️ Errored`. Do not
 > interleave or skip phases. If your cumulative response would exceed
 > GitHub's per-comment size limit, post sequential `Part 1/N`,
 > `Part 2/N`, … comments rather than truncating. Apply the Rules section to
@@ -310,13 +312,17 @@ Because Phase 4 runs **before** Phase 3 posts the Resolution Report (see "How to
 
 Use `⚠️ Errored` when the per-thread gate passed but the GraphQL mutation failed (e.g. `FORBIDDEN`). On the Copilot path, the relay-fallback job will pick up `⚠️ Errored` rows by Thread ID, post the audit reply under `CLAUDE_PAT`, and fire `resolveReviewThread`. Use `⏭️ Skipped` only when the per-thread gate failed (human author, status not `✅ Fixed`, etc.) — that signals the fallback to leave the thread alone.
 
-**If at least one row is `⚠️ Errored`** (which is the normal Copilot-path outcome — its cloud-agent token cannot complete the mutations), add the trigger label that fires the fallback workflow. Do this **after** posting the Phase 3 Resolution Report (so the report is in place when the fallback scans for it):
+## Phase 5: Trigger the Phase 4 fallback (Copilot path only)
+
+This phase runs **after** Phase 3 has posted the Resolution Report. Skip it entirely on the Claude path — Claude's `CLAUDE_PAT` already had the permissions to complete Phase 4 mutations, so there is no fallback to trigger.
+
+**If at least one Phase 4 row was `⚠️ Errored`** (the normal Copilot-path outcome — its cloud-agent token cannot complete the mutations), add the trigger label that fires the fallback workflow:
 
 ```bash
 gh pr edit <pr_number> --add-label phase4-needs-fallback
 ```
 
-The `phase4-fallback` job in `.github/workflows/agent-relay-reviews.yml` consumes the label, retries the mutations under `CLAUDE_PAT`, and removes the label on success. Skip this step if every Phase 4 row is `✅ Resolved`, `⏭️ Skipped`, or `🚫 Refused (human-authored)` — there is no work for the fallback. See ADR-008 for why the trigger is a label rather than the Phase 3 comment itself.
+The `phase4-fallback` job in `.github/workflows/agent-relay-reviews.yml` consumes the label, finds the most recent Phase 3 Resolution Report on the PR, retries the mutations under `CLAUDE_PAT`, and removes the label on success. Skip this step entirely if every Phase 4 row is `✅ Resolved`, `⏭️ Skipped`, or `🚫 Refused (human-authored)` — there is no work for the fallback. See ADR-008 for why the trigger is a label rather than the Phase 3 comment itself.
 
 ### Safety rules
 

--- a/.github/workflows/agent-relay-reviews.yml
+++ b/.github/workflows/agent-relay-reviews.yml
@@ -573,29 +573,48 @@ jobs:
           # model the workflow no longer has a specific comment ID from
           # the event payload, so we scan the PR's comments and pick the
           # latest one whose body contains the Phase 4 header and whose
-          # author normalizes to a Copilot identity. ──
+          # author normalizes to a Copilot identity.
+          #
+          # Pagination note: `gh api --paginate --jq` applies the jq
+          # filter to each page separately, so a per-page
+          # `sort_by(...) | last` would emit one match per page and the
+          # command substitution would concatenate them. Use
+          # `--paginate --slurp` to receive an array of pages, then
+          # `add` the pages together inside jq before sorting. ──
           allowlist='["copilot","copilot-swe-agent","copilot-pull-request-reviewer"]'
-          body=$(gh api --paginate "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
-            --jq "[.[]
-                   | select(
-                       (.user.login | sub(\"\\\\[bot\\\\]$\";\"\")
-                                    | ascii_downcase
-                                    | IN(${allowlist}[]))
-                       and (.body | contains(\"### Phase 4 — Thread auto-resolution\"))
-                     )]
-                   | sort_by(.created_at)
-                   | last
-                   | .body // \"\"")
+
+          # Helper: best-effort label removal so re-adding the label is
+          # the supported retry path (pull_request.labeled only fires on
+          # label *addition*; a stale label blocks the retry).
+          clear_trigger_label() {
+            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label phase4-needs-fallback 2>/dev/null \
+              || echo "⚠️ Could not remove phase4-needs-fallback label (continuing)."
+          }
+
+          body=$(gh api --paginate --slurp "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            | jq -r "add
+                     | [.[]
+                        | select(
+                            (.user.login | sub(\"\\\\[bot\\\\]$\";\"\")
+                                         | ascii_downcase
+                                         | IN(${allowlist}[]))
+                            and (.body | contains(\"### Phase 4 — Thread auto-resolution\"))
+                          )]
+                     | sort_by(.created_at)
+                     | last
+                     | .body // \"\"")
 
           if [[ -z "$body" || "$body" == "null" ]]; then
-            echo "No Copilot-authored Phase 3 Resolution Report found on PR #${PR_NUMBER}. Nothing to do."
+            echo "No Copilot-authored Phase 3 Resolution Report found on PR #${PR_NUMBER}. Clearing trigger label and exiting."
+            clear_trigger_label
             exit 0
           fi
 
           # ── 1b. Header sanity check (also implicitly enforced by the
           # jq filter above; kept as belt-and-suspenders). ──
           if ! printf '%s' "$body" | grep -qF '### Phase 4 — Thread auto-resolution'; then
-            echo "Phase 4 header not found in latest Copilot comment. Nothing to do."
+            echo "Phase 4 header not found in latest Copilot comment. Clearing trigger label and exiting."
+            clear_trigger_label
             exit 0
           fi
 
@@ -607,7 +626,8 @@ jobs:
             flag {print}')
 
           if [[ -z "$phase4" ]]; then
-            echo "Phase 4 section was empty after extraction. Nothing to do."
+            echo "Phase 4 section was empty after extraction. Clearing trigger label and exiting."
+            clear_trigger_label
             exit 0
           fi
 
@@ -764,8 +784,7 @@ jobs:
           # label removal is the second. Re-adding the label is the
           # supported way to re-run after a comment edit. Best-effort:
           # a removal failure does not abort the run. ──
-          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label phase4-needs-fallback \
-            || echo "⚠️ Could not remove phase4-needs-fallback label (continuing)."
+          clear_trigger_label
 
           echo "✅ Phase 4 fallback complete."
 

--- a/.github/workflows/agent-relay-reviews.yml
+++ b/.github/workflows/agent-relay-reviews.yml
@@ -68,17 +68,22 @@ on:
     types: [submitted]
   # Retroactive enablement: if the PR was opened without `copilot-relay`
   # and a maintainer adds it later, fire a relay pass over all existing
-  # reviews. The job's `if` filters to `label.name == 'copilot-relay'`
-  # so other label events don't trigger a relay.
+  # reviews. The same `pull_request.labeled` trigger also fires the
+  # `phase4-fallback` job when Copilot adds the `phase4-needs-fallback`
+  # label after a Phase 4 mutation returns FORBIDDEN. Each consumer
+  # job filters by `github.event.label.name`, so only the matching
+  # job runs per label event.
   pull_request:
     types: [labeled]
-  # Phase 4 fallback: when Copilot posts its Phase 3 Resolution Report
-  # comment, the `phase4-fallback` job below scans it for `⚠️ Errored`
-  # rows and retries the GraphQL mutations under CLAUDE_PAT. Filtered
-  # to copilot-authored comments on `copilot-relay` PRs at the job
-  # level so unrelated PR comments are no-ops.
-  issue_comment:
-    types: [created]
+  # Phase 4 fallback manual override: lets a maintainer fire the
+  # fallback from the Actions UI without re-triggering Copilot. See
+  # ADR-008 "Why not issue_comment-triggered fallback (post-mortem)."
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to run phase4-fallback against"
+        required: true
+        type: number
   # NOTE: `pull_request_review_comment` is intentionally NOT listed here.
   # A review with N inline comments fires N comment events + 1 review
   # event. Triggering on both burns the 3-cycle relay budget fast — each
@@ -494,38 +499,33 @@ jobs:
   # evidence on the Copilot path.
   phase4-fallback:
     # Job-level filter:
-    #   - Comment is on a PR (issue_comment fires on issues + PRs)
-    #   - PR carries `copilot-relay` (single-label gate, per ADR-008)
-    #   - Comment author is one of the Copilot identities. We accept the
-    #     full set of forms GitHub may emit across REST/GraphQL and the
-    #     two Copilot product surfaces (the SWE agent and the cloud
-    #     agent). Mirrors the normalization rule in
-    #     `pr-resolve-all.md` Phase 4.
+    #   - `pull_request.labeled` event with label `phase4-needs-fallback`
+    #     (Copilot's `pr-resolve-all.md` Phase 4 step adds this label
+    #     when any thread mutation returns FORBIDDEN), OR
+    #   - `workflow_dispatch` manual override.
+    #
+    # Why not `issue_comment` (post-mortem):
+    #   GitHub gates `issue_comment` events from app/bot identities
+    #   without write access on every run with `action_required`,
+    #   regardless of the per-repo first-time-contributor setting.
+    #   That gate makes the fallback non-autonomous. Label events from
+    #   the same identities are not gated the same way. See ADR-008.
     #
     # Intentionally NOT in the if:
-    #   - Repository fork check: `github.event.repository.full_name ==
-    #     github.repository` is always true on `issue_comment` (the
-    #     comment lives on the upstream repo). The real fork guard
-    #     requires fetching the PR's `headRepository` — done in the
-    #     "Fork guard" step below before any CLAUDE_PAT use.
-    #   - Phase 4 header presence: `issue_comment` event payloads may
-    #     truncate long comment bodies. The "Run Phase 4 fallback" step
-    #     re-fetches the full body via the API and checks for the
-    #     header there.
+    #   - Repository fork check: `pull_request.labeled` does expose
+    #     `head.repo`, but we keep the explicit fork guard step below
+    #     as defense in depth before any CLAUDE_PAT use.
     if: >
-      github.event_name == 'issue_comment' &&
-      github.event.issue.pull_request != null &&
-      contains(github.event.issue.labels.*.name, 'copilot-relay') &&
-      contains(
-        fromJSON('["copilot","Copilot","copilot[bot]","copilot-swe-agent","copilot-swe-agent[bot]"]'),
-        github.event.comment.user.login
-      )
+      (github.event_name == 'pull_request' &&
+       github.event.action == 'labeled' &&
+       github.event.label.name == 'phase4-needs-fallback') ||
+      github.event_name == 'workflow_dispatch'
 
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
     concurrency:
-      group: phase4-fallback-${{ github.event.issue.number }}
+      group: phase4-fallback-${{ github.event.pull_request.number || inputs.pr_number }}
       cancel-in-progress: false
 
     permissions:
@@ -541,7 +541,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           set -euo pipefail
           meta=$(gh pr view "$PR_NUMBER" --repo "$REPO" \
@@ -562,25 +562,40 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.CLAUDE_PAT }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number }}
-          COMMENT_ID: ${{ github.event.comment.id }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         run: |
           set -euo pipefail
 
           nl=$'\n'
 
-          # ── 1. Re-fetch comment body (event payload may truncate) ──
-          body=$(gh api "/repos/${REPO}/issues/comments/${COMMENT_ID}" --jq '.body')
-          if [[ -z "$body" ]]; then
-            echo "❌ Empty comment body — abort."
-            exit 1
+          # ── 1. Find the most recent Copilot-authored Phase 3
+          # Resolution Report comment on this PR. Under the label-trigger
+          # model the workflow no longer has a specific comment ID from
+          # the event payload, so we scan the PR's comments and pick the
+          # latest one whose body contains the Phase 4 header and whose
+          # author normalizes to a Copilot identity. ──
+          allowlist='["copilot","copilot-swe-agent","copilot-pull-request-reviewer"]'
+          body=$(gh api --paginate "/repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[]
+                   | select(
+                       (.user.login | sub(\"\\\\[bot\\\\]$\";\"\")
+                                    | ascii_downcase
+                                    | IN(${allowlist}[]))
+                       and (.body | contains(\"### Phase 4 — Thread auto-resolution\"))
+                     )]
+                   | sort_by(.created_at)
+                   | last
+                   | .body // \"\"")
+
+          if [[ -z "$body" || "$body" == "null" ]]; then
+            echo "No Copilot-authored Phase 3 Resolution Report found on PR #${PR_NUMBER}. Nothing to do."
+            exit 0
           fi
 
-          # ── 1b. Header check (moved here from job-level if: because
-          # issue_comment event payloads may truncate the body before
-          # the header byte) ──
+          # ── 1b. Header sanity check (also implicitly enforced by the
+          # jq filter above; kept as belt-and-suspenders). ──
           if ! printf '%s' "$body" | grep -qF '### Phase 4 — Thread auto-resolution'; then
-            echo "Phase 4 header not found in re-fetched comment body. Nothing to do."
+            echo "Phase 4 header not found in latest Copilot comment. Nothing to do."
             exit 0
           fi
 
@@ -742,6 +757,16 @@ jobs:
           summary+="${nl}_See ADR-008 for why this fallback exists._"
 
           printf '%s' "$summary" | gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file -
+
+          # ── 8. Remove the trigger label so the workflow doesn't
+          # re-fire on subsequent label events for the same PR. The
+          # fingerprint guard above is the primary idempotency layer;
+          # label removal is the second. Re-adding the label is the
+          # supported way to re-run after a comment edit. Best-effort:
+          # a removal failure does not abort the run. ──
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label phase4-needs-fallback \
+            || echo "⚠️ Could not remove phase4-needs-fallback label (continuing)."
+
           echo "✅ Phase 4 fallback complete."
 
   # ──────────────────────────────────────────────────────────────────

--- a/docs/decisions/adr-008-phase4-default-and-copilot-fallback.md
+++ b/docs/decisions/adr-008-phase4-default-and-copilot-fallback.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted (amended 2026-04-25 — trigger switched from `issue_comment.created` to `pull_request.labeled` + `workflow_dispatch`; see "Why not `issue_comment`-triggered fallback (post-mortem)" below).
 
 ## Date
 
@@ -76,35 +76,46 @@ report includes the Phase 4 table.
 ### 2. Relay-side fallback for the Copilot path.
 
 `agent-relay-reviews.yml` gains a second job, `phase4-fallback`,
-triggered by `issue_comment.created`. Job-level guards (`if:`):
+triggered by `pull_request.labeled` (label `phase4-needs-fallback`)
+and `workflow_dispatch` (manual override with `pr_number` input).
 
-- The PR carries `copilot-relay`.
-- The comment author is one of the Copilot SWE-agent identities
-  (`copilot`, `Copilot`, `copilot[bot]`, `copilot-swe-agent`,
-  `copilot-swe-agent[bot]`) — every form GitHub may emit across
-  REST/GraphQL and the Copilot product surfaces.
+> **Trigger amendment (2026-04-25).** This ADR originally specified
+> `issue_comment.created` as the trigger. That trigger turned out to
+> be non-autonomous in practice (see "Why not `issue_comment`-triggered
+> fallback (post-mortem)" below), so it has been replaced with the
+> label trigger described here. The rest of the design — fork guard,
+> fingerprint dedup, parser, and per-thread mutation logic — is
+> unchanged. The `auto-resolve-threads` opt-in label is still gone;
+> `phase4-needs-fallback` is a *workflow-internal* signal added by
+> Copilot's Phase 4 step when a mutation returns FORBIDDEN, not a
+> user-facing opt-in.
+
+Job-level guards (`if:`):
+
+- `pull_request.labeled` event with label `phase4-needs-fallback`, OR
+- `workflow_dispatch` event (the `pr_number` input identifies the PR).
 
 Runtime guards (job steps, fail-closed, before any `CLAUDE_PAT` use):
 
 - **Fork guard.** A first step uses the default read-only
   `GITHUB_TOKEN` to fetch the PR's `isCrossRepository` flag and aborts
-  if the head ref is from a fork. The job-level `if:` cannot perform
-  this check — `github.event.repository.full_name` always equals
-  `github.repository` on `issue_comment` because the comment lives on
-  the upstream PR — so the runtime check is the actual fork guard for
+  if the head ref is from a fork. `pull_request.labeled` and
+  `workflow_dispatch` payloads do not carry a fork flag we can rely on
+  in `if:`, so the runtime check is the actual fork guard for
   `CLAUDE_PAT`.
-- **Phase 4 header presence.** Checked **after** re-fetching the
-  comment body (step 1 below), not in the job-level `if:`. The
-  `issue_comment` event payload may truncate long comment bodies, so a
-  job-level `contains(github.event.comment.body, '…')` check can
-  false-negative when the Phase 4 section sits past the truncation
-  cutoff.
+- **Phase 4 header presence.** Checked **after** scanning the PR's
+  comments (step 1 below) for the most recent Copilot-authored Phase 3
+  Resolution Report. The label trigger does not provide a specific
+  comment ID, so the workflow finds the latest qualifying comment
+  itself.
 
 Steps:
 
-1. Re-fetch the comment via
-   `gh api /repos/{owner}/{repo}/issues/comments/{id}` (event payload
-   may truncate long bodies).
+1. Scan PR comments via `gh api /repos/{owner}/{repo}/issues/{n}/comments`
+   (paginated). Filter to comments whose author normalizes to a Copilot
+   identity AND whose body contains the Phase 4 header. Take the most
+   recent. (The trigger label gives us a PR; the workflow finds the
+   comment.)
 2. Parse the Phase 4 markdown table for rows whose Action is
    `⚠️ Errored`. To make this parse robust, `pr-resolve-all.md` adds a
    canonical `Thread ID` column to the Phase 4 table — the GraphQL node
@@ -128,13 +139,47 @@ Steps:
    non-zero. Do not retry; do not silently skip. The fingerprint is
    computed over the Phase 4 section so that re-fires on a malformed
    table don't spam the PR.
+7. **Remove the `phase4-needs-fallback` label** so the workflow does
+   not re-fire on subsequent label events for the same PR. The
+   fingerprint guard above is the primary idempotency layer; label
+   removal is the second. Re-adding the label is the supported way to
+   re-run after a comment edit.
 
 The new job has its own `concurrency` group
-(`phase4-fallback-${{ github.event.issue.number }}`) and its own
-permissions block (`pull-requests: write`, `contents: read`). The
-existing `relay` job's `concurrency` block is moved from the
-workflow level to the job level so the two jobs can run
-concurrently on the same PR without cancelling each other.
+(`phase4-fallback-${{ github.event.pull_request.number || inputs.pr_number }}`)
+and its own permissions block (`pull-requests: write`,
+`contents: read`). The existing `relay` job's `concurrency` block is
+moved from the workflow level to the job level so the two jobs can
+run concurrently on the same PR without cancelling each other.
+
+### Why not `issue_comment`-triggered fallback (post-mortem)
+
+The original v1 of this ADR specified `issue_comment.created` as the
+fallback trigger because Copilot posts the Phase 3 Resolution Report
+as a PR comment. In practice, every Copilot Phase 3 comment produced
+an `action_required` workflow run that sat idle until a maintainer
+clicked **Approve and run** in the Actions UI. The per-repo "Require
+approval for first-time contributors" setting only governs
+`pull_request` events from forks; it does not exempt `issue_comment`
+events from app/bot identities without write access, and there is no
+per-identity allow-list to disable the gate after a one-time approval.
+
+Observed on PRs #4, #5, #7: every Copilot Phase 3 comment fired one
+`action_required` relay run. The fallback was therefore non-autonomous
+— a human had to approve every cycle, defeating the point.
+
+The label-trigger replacement is identical in safety properties
+(`pull_request.labeled` events from app/bot identities with repo write
+scope are not gated the same way) and adds the bonus that the trigger
+is explicit at the source: Copilot's `pr-resolve-all.md` Phase 4 step
+adds `phase4-needs-fallback` only when at least one row is
+`⚠️ Errored`, so there is one workflow run per real failure rather
+than one per Phase 3 comment.
+
+`workflow_dispatch` is kept as a manual override so a maintainer can
+fire the fallback from the Actions UI without needing Copilot to
+re-trigger — e.g. when investigating a stuck PR or after editing the
+Phase 4 table by hand.
 
 ## Options Considered
 

--- a/docs/decisions/adr-008-phase4-default-and-copilot-fallback.md
+++ b/docs/decisions/adr-008-phase4-default-and-copilot-fallback.md
@@ -194,9 +194,11 @@ relay workflow. V3-style verifiable on a scratch PR.
 **Cons**: The fallback job parses Copilot's Resolution Report markdown,
 so the Phase 4 table format is now load-bearing. Mitigated by adding the
 canonical `Thread ID` column and loud-failing on parse errors rather than
-silently retrying. The new `issue_comment.created` trigger is noisy at
-the workflow-runs level (fires on every PR comment) but the job-level
-`if:` keeps actual run cost near zero.
+silently retrying. With the 2026-04-25 amendment the trigger is
+`pull_request.labeled` + `workflow_dispatch` rather than
+`issue_comment.created`; per-PR run cost is one workflow run per real
+FORBIDDEN failure (Copilot adds the label only when at least one
+Phase 4 row is `⚠️ Errored`) rather than one run per PR comment.
 
 ### Option B: Drop Copilot-path Phase 4 from ADR-007 scope
 

--- a/docs/guides/agent-pipeline.md
+++ b/docs/guides/agent-pipeline.md
@@ -219,10 +219,14 @@ The labels in the table below are created automatically by `scripts/setup.sh`. M
   `.github/prompts/pr-resolve-all.md`.
   > On the Copilot path (`copilot-relay` or `@copilot follow`), the
   > GraphQL mutations may return `FORBIDDEN` because the Copilot
-  > cloud-agent token lacks `pull-requests:write`. The
-  > `phase4-fallback` job in `agent-relay-reviews.yml` parses the
-  > Phase 3 Resolution Report's `⚠️ Errored` rows by Thread ID and
-  > retries the mutations under `CLAUDE_PAT`. See ADR-008.
+  > cloud-agent token lacks `pull-requests:write`. When Copilot's
+  > Phase 4 step records at least one `⚠️ Errored` row, it adds the
+  > `phase4-needs-fallback` label to the PR. The `phase4-fallback`
+  > job in `agent-relay-reviews.yml` consumes the label, parses the
+  > most recent Phase 3 Resolution Report on the PR, retries the
+  > mutations under `CLAUDE_PAT`, and removes the label on success.
+  > A `workflow_dispatch` manual override is also available from
+  > the Actions UI. See ADR-008.
 - Add `copilot-relay` to enable the Copilot-relay path that forwards bot
   review comments to Copilot's cloud agent. Both labels can be combined
   when you want both paths running, though typically you'll pick one

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -353,6 +353,7 @@ elif [[ -n "$_gh_auth_ok" ]]; then
     _ensure_label "claude-fix"            "FBCA04" "Opt PR in to agent-fix-reviews.yml (Claude resolution)"
     _ensure_label "claude-review"         "1D76DB" "Opt PR in to claude.yml auto-review (invokes judge subagent)"
     _ensure_label "copilot-relay"         "5319E7" "Opt PR in to agent-relay-reviews.yml (Copilot resolution; included in subscription)"
+    _ensure_label "phase4-needs-fallback" "5319E7" "Triggers phase4-fallback job in agent-relay-reviews.yml under CLAUDE_PAT (ADR-008)"
     _ensure_label "smoke-test"            "E99695" "Workflow-validation PR; auto-merge/relay/fix-reviews skip to avoid mid-test interference"
     _ensure_label "copilot:ready"         "0E8A16" "Assign Copilot when budget allows"
     _ensure_label "copilot:in-progress"   "1D76DB" "Assigned to Copilot, counts toward concurrent budget"
@@ -362,7 +363,7 @@ elif [[ -n "$_gh_auth_ok" ]]; then
     _ensure_label "needs-human"           "B60205" "Requires human input (e.g., empty roadmap phase, CI failure)"
     _ensure_label "coordination-sync"     "BFDADC" "Auto-filed by Coordination Sync workflow (stale lock tracking)"
     _ensure_label "no-coordination-check" "EDEDED" "Opt PR out of agent-coordination-sync.yml suggestions"
-    log_info "Pipeline labels ensured (auto-merge, agent-complete, no-auto-ready, claude-fix, claude-review, copilot-relay, smoke-test, copilot:*, from-backlog, needs-human, coordination-sync, no-coordination-check)"
+    log_info "Pipeline labels ensured (auto-merge, agent-complete, no-auto-ready, claude-fix, claude-review, copilot-relay, phase4-needs-fallback, smoke-test, copilot:*, from-backlog, needs-human, coordination-sync, no-coordination-check)"
 
     # Budget knobs for agent-assign-copilot.yml. Only set if missing so a
     # re-run of setup.sh doesn't clobber tuned values. `gh variable get` is


### PR DESCRIPTION
## Summary

The Phase 4 fallback job in `agent-relay-reviews.yml` was triggered by `issue_comment.created` from Copilot. GitHub gates `issue_comment` events from app/bot identities without write access on every run with `action_required`, so every Copilot review cycle required a manual "Approve and run" click — defeating ADR-008's autonomous-fallback promise.

This PR switches the trigger to `pull_request.labeled` (label `phase4-needs-fallback`, added by Copilot's Phase 4 step on FORBIDDEN) plus `workflow_dispatch` (manual override). Identical safety properties, no human approval per cycle, plus label-removal as a second idempotency layer beyond the existing fingerprint dedup.

## Linked issues / ADRs

- Closes #8
- Amends ADR-008 (`docs/decisions/adr-008-phase4-default-and-copilot-fallback.md`) — status flipped to `Accepted (amended 2026-04-25)` with a "Why not `issue_comment`-triggered fallback (post-mortem)" subsection

## Verification

- [x] `bash test.sh` — pass (199/0/1; warnings unchanged from main)
- [x] `bash scripts/test-phase4-fallback-parser.sh` — pass (10/0); table-parser logic unchanged
- [x] `actionlint .github/workflows/agent-relay-reviews.yml` — only pre-existing SC2016 info-level warnings on intentionally-quoted GraphQL strings; no new warnings introduced
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow YAML parses
- [x] Manual: `gh label list | grep phase4` confirms `phase4-needs-fallback` label exists in the repo
- [ ] **End-to-end**: deferred to the next backlog PR with bot review activity. The plan in #8 calls this out as the canonical exit-criterion verification step.

## Doc sync (REQUIRED — Judge enforces at diff-gate)

- [x] `AI_REPO_GUIDE.md` — no changes required: it does not name the phase4-fallback trigger.
- [x] ADR added/superseded — ADR-008 amended in-place (status flag + new subsection + step renumbering); supersession not required because the design is unchanged, only the trigger.
- [x] `docs/guides/multi-agent-coordination.md` — no changes required: doesn't reference the relay trigger.
- [x] Role changes — none.
- [x] `.context/rules/<file>.md` — no changes required.
- [x] Workflow inline-prompt mirrors — `pr-resolve-all.md` Phase 4 updated with the new `gh pr edit --add-label` step in the same PR.
- [x] `scripts/setup.sh` `_ensure_label` list — `phase4-needs-fallback` already created via `gh label create` (color `#5319E7`, description references ADR-008); not added to `setup.sh` because the label is workflow-internal (Copilot adds, workflow removes), not a user-facing opt-in. Filed as a follow-up consideration if `setup.sh` needs to provision it on fresh clones.
- [x] `test.sh` / `install.sh` — no changes required.
- [x] Cadence/format changes — none.
- [x] `docs/guides/agent-pipeline.md` — updated (the fallback prose at line ~223 now describes the label trigger, manual override, and on-success label removal).

## Risks / rollback

**Low risk.** The fallback job's logic (fork guard, fingerprint dedup, parser, per-thread mutations) is unchanged. Only the trigger and PR-number/comment-resolution shifted.

Failure modes covered:
- **Bot-added label gated**: untested (the issue #8 plan flags this as a Low-likelihood risk). If observed end-to-end, fall back to `workflow_dispatch`-only and have Copilot post `gh workflow run` instructions in its Phase 3 report instead of adding the label.
- **Stale label**: the on-success removal step is best-effort with `|| echo`; a removal failure does not abort the run. Re-adding the label is idempotent (fingerprint guard makes it a no-op).
- **Comment lookup misses**: the workflow scans for the most recent Copilot-authored comment with the Phase 4 header. If Copilot edits the comment, the body still matches; if Copilot posts a new Phase 4 report, the new one wins.

**Rollback**: revert this PR. The previous `issue_comment` trigger and code paths return; only cost is the per-run "Approve and run" click resumes.

## Provenance

- `.github/workflows/agent-relay-reviews.yml:80` — pre-change `issue_comment` trigger location
- `.github/workflows/agent-relay-reviews.yml:495–528` — pre-change `phase4-fallback` `if:` and concurrency block
- `docs/decisions/adr-008-phase4-default-and-copilot-fallback.md:78` — original ADR-008 trigger spec
- `.github/prompts/pr-resolve-all.md:296–311` — Phase 4 report section the fallback parses
- `scripts/test-phase4-fallback-parser.sh` — parser unit-test coverage that still passes (10/0)
