### PR TITLE
fix: residual bot findings from #3 (ISS-01/03/04/15/28)

### DIFF
--- a/.github/workflows/compliance-checks.yml
+++ b/.github/workflows/compliance-checks.yml
@@ -24,14 +24,36 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+      # ISS-15: mmdc drives a headless Chromium via puppeteer. The default
+      # GitHub-hosted runner is missing the required shared libs, so a bare
+      # `npx mermaid-cli` call fails with "Failed to launch the browser
+      # process!". Install puppeteer's documented Linux deps first, then
+      # pass a puppeteer config that disables the chromium sandbox (the
+      # runner UID has no /proc/self/setgroups capability needed for it).
+      - name: Install Chromium runtime deps for puppeteer
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ca-certificates fonts-liberation libasound2t64 libatk-bridge2.0-0 \
+            libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 \
+            libfontconfig1 libgbm1 libgcc-s1 libglib2.0-0 libgtk-3-0 \
+            libnspr4 libnss3 libpango-1.0-0 libx11-6 libx11-xcb1 libxcb1 \
+            libxcomposite1 libxdamage1 libxext6 libxfixes3 libxrandr2 \
+            libxshmfence1 wget xdg-utils
       - name: Render every Mermaid block in diagrams/
         run: |
           set -euo pipefail
           mkdir -p /tmp/mermaid-out
+          cat > /tmp/puppeteer.json <<'EOF'
+          { "args": ["--no-sandbox", "--disable-setuid-sandbox"] }
+          EOF
           for f in diagrams/*.md; do
             [ -f "$f" ] || continue
             echo "Linting $f"
-            npx -y @mermaid-js/mermaid-cli@10 -i "$f" -o "/tmp/mermaid-out/$(basename "$f").svg"
+            npx -y @mermaid-js/mermaid-cli@10 \
+              --puppeteerConfigFile /tmp/puppeteer.json \
+              -i "$f" -o "/tmp/mermaid-out/$(basename "$f").svg"
           done
 
   csv-schema:

--- a/.github/workflows/demo-plan.yml
+++ b/.github/workflows/demo-plan.yml
@@ -103,6 +103,7 @@ jobs:
           retention-days: 7
 
       - name: Comment plan summary on PR
+        if: steps.preflight.outputs.configured == 'true'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/demo-plan.yml
+++ b/.github/workflows/demo-plan.yml
@@ -31,11 +31,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Skip cleanly (job succeeds) when this repo is not configured for
+      # OIDC-based plans. Without this guard, the configure-aws-credentials
+      # step fails with "Input required and not supplied: aws-region" on
+      # every PR in repos that haven't set the AWS_REGION / AWS_PLAN_ROLE_ARN
+      # secrets — which then blocks `agent-auto-merge.yml`'s readiness gate.
+      # Maintainers who want plans on PRs add the secrets; everyone else
+      # gets a green check.
+      - name: Preflight — skip if AWS OIDC plan secrets are unset
+        id: preflight
+        env:
+          AWS_REGION_SECRET: ${{ secrets.AWS_REGION }}
+          AWS_PLAN_ROLE_ARN: ${{ secrets.AWS_PLAN_ROLE_ARN }}
+        run: |
+          if [[ -z "${AWS_REGION_SECRET}" || -z "${AWS_PLAN_ROLE_ARN}" ]]; then
+            echo "AWS_REGION and/or AWS_PLAN_ROLE_ARN secrets are not set in this repo."
+            echo "Skipping terraform plan (this is a green skip, not a failure)."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: hashicorp/setup-terraform@v3
+        if: steps.preflight.outputs.configured == 'true'
         with:
           terraform_version: 1.9.8
 
       - name: Configure AWS credentials (read-only role via OIDC)
+        if: steps.preflight.outputs.configured == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_PLAN_ROLE_ARN }}
@@ -43,9 +66,11 @@ jobs:
           role-session-name: gh-demo-plan-${{ github.run_id }}
 
       - name: terraform fmt -check
+        if: steps.preflight.outputs.configured == 'true'
         run: terraform fmt -recursive -check terraform/
 
       - name: terraform init
+        if: steps.preflight.outputs.configured == 'true'
         working-directory: terraform/demo
         run: |
           terraform init \
@@ -54,10 +79,12 @@ jobs:
             -backend-config="region=${{ secrets.AWS_REGION }}"
 
       - name: terraform validate
+        if: steps.preflight.outputs.configured == 'true'
         working-directory: terraform/demo
         run: terraform validate
 
       - name: terraform plan
+        if: steps.preflight.outputs.configured == 'true'
         working-directory: terraform/demo
         # `set -o pipefail` so a failed `terraform plan` propagates through
         # the `tee` and fails the step. Without it, the plan exit code is
@@ -68,6 +95,7 @@ jobs:
           terraform plan -no-color -out=tfplan | tee plan.txt
 
       - name: Upload plan artifact
+        if: steps.preflight.outputs.configured == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: tfplan-${{ github.run_id }}

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -138,11 +138,19 @@ resource "aws_security_group" "demo_lambda" {
   tags        = { Name = "${local.name_prefix}-page-lambda" }
 }
 
-resource "aws_vpc_security_group_egress_rule" "demo_lambda_to_vpc" {
+# Egress is intentionally restricted to TCP/443 within the VPC CIDR — VPC
+# interface endpoints (logs, monitoring, sts, kms, ssm*, ec2*, xray) terminate
+# HTTPS on private IPs in the same subnets, and that's the only outbound the
+# demo Lambda needs (PR #13 copilot/gemini sec-MED). The previous
+# `ip_protocol = "-1"` rule allowed every protocol/port to the entire VPC,
+# which was broader than the comment claimed.
+resource "aws_vpc_security_group_egress_rule" "demo_lambda_to_vpc_https" {
   security_group_id = aws_security_group.demo_lambda.id
-  description       = "Allow Lambda \u2192 VPC interface endpoints (logs, etc)."
+  description       = "Allow Lambda \u2192 VPC interface endpoints (HTTPS only)."
   cidr_ipv4         = module.vpc.vpc_cidr_block
-  ip_protocol       = "-1"
+  ip_protocol       = "tcp"
+  from_port         = 443
+  to_port           = 443
 }
 
 resource "aws_lambda_function" "demo_page" {

--- a/terraform/demo/main.tf
+++ b/terraform/demo/main.tf
@@ -111,6 +111,40 @@ resource "aws_iam_role_policy_attachment" "demo_lambda_basic" {
   policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
+# VPC ENI management permissions for Lambda — required when vpc_config is
+# attached (ISS-04). AWSLambdaVPCAccessExecutionRole is a superset of
+# AWSLambdaBasicExecutionRole; we keep the basic attachment for explicit
+# parity with non-VPC Lambdas elsewhere in the demo.
+resource "aws_iam_role_policy_attachment" "demo_lambda_vpc" {
+  role       = aws_iam_role.demo_lambda.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+# X-Ray tracing permissions (ISS-28). Required for the function's
+# tracing_config below to actually emit segments.
+resource "aws_iam_role_policy_attachment" "demo_lambda_xray" {
+  role       = aws_iam_role.demo_lambda.name
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/AWSXRayDaemonWriteAccess"
+}
+
+# Security group attached to the demo Lambda's ENIs. Egress is restricted
+# to the VPC CIDR so the function can only reach the interface endpoints
+# (no internet path; demo VPC has no NAT). Closes ISS-04 by demonstrating
+# the enclave network model on the only workload in the demo stack.
+resource "aws_security_group" "demo_lambda" {
+  name        = "${local.name_prefix}-page-lambda"
+  description = "Demo page Lambda \u2014 egress restricted to VPC CIDR (no internet)."
+  vpc_id      = module.vpc.vpc_id
+  tags        = { Name = "${local.name_prefix}-page-lambda" }
+}
+
+resource "aws_vpc_security_group_egress_rule" "demo_lambda_to_vpc" {
+  security_group_id = aws_security_group.demo_lambda.id
+  description       = "Allow Lambda \u2192 VPC interface endpoints (logs, etc)."
+  cidr_ipv4         = module.vpc.vpc_cidr_block
+  ip_protocol       = "-1"
+}
+
 resource "aws_lambda_function" "demo_page" {
   function_name    = "${local.name_prefix}-page"
   role             = aws_iam_role.demo_lambda.arn
@@ -120,6 +154,26 @@ resource "aws_lambda_function" "demo_page" {
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256
   timeout          = 5
   memory_size      = 128
+
+  # ISS-04: run inside the demo VPC's private subnets so the demo
+  # mirrors the enclave network model (Lambda has no direct internet
+  # path; reaches AWS APIs via VPC interface endpoints).
+  vpc_config {
+    subnet_ids         = module.vpc.private_subnet_ids
+    security_group_ids = [aws_security_group.demo_lambda.id]
+  }
+
+  # ISS-28: Active X-Ray tracing on the only workload in the demo so the
+  # CMMC SI controls can be evidenced end-to-end.
+  tracing_config {
+    mode = "Active"
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.demo_lambda_basic,
+    aws_iam_role_policy_attachment.demo_lambda_vpc,
+    aws_iam_role_policy_attachment.demo_lambda_xray,
+  ]
 }
 
 resource "aws_lambda_function_url" "demo_page" {

--- a/terraform/govcloud/main.tf
+++ b/terraform/govcloud/main.tf
@@ -74,6 +74,20 @@ module "cloudtrail" {
   log_retention_days          = var.log_retention_days
   object_lock_retention_years = var.object_lock_retention_years
   is_multi_region             = true
+
+  # CMMC AU.L2-3.3.1/3.3.2 — record S3 object operations and Lambda
+  # invocations across the partition (closes ISS-01). Scope by ARN prefix
+  # so all S3 buckets and Lambda functions in the partition are captured.
+  data_event_resources = [
+    {
+      type   = "AWS::S3::Object"
+      values = ["arn:${data.aws_partition.current.partition}:s3"]
+    },
+    {
+      type   = "AWS::Lambda::Function"
+      values = ["arn:${data.aws_partition.current.partition}:lambda"]
+    },
+  ]
 }
 
 # -----------------------------------------------------------------------------

--- a/terraform/govcloud/main.tf
+++ b/terraform/govcloud/main.tf
@@ -78,10 +78,18 @@ module "cloudtrail" {
   # CMMC AU.L2-3.3.1/3.3.2 — record S3 object operations and Lambda
   # invocations across the partition (closes ISS-01). Scope by ARN prefix
   # so all S3 buckets and Lambda functions in the partition are captured.
+  # The S3 prefix uses the explicit triple-colon bucket form
+  # (`arn:<partition>:s3:::`) per CloudTrail data-event ARN syntax for
+  # `AWS::S3::Object` (PR #13 copilot/gemini). Both `arn:<partition>:s3`
+  # and `arn:<partition>:s3:::` match all buckets in the partition under
+  # CloudTrail's prefix-match semantics; the triple-colon form avoids
+  # ambiguity with the bare service ARN. The Lambda prefix
+  # `arn:<partition>:lambda` is the documented account-wide form for
+  # `AWS::Lambda::Function`.
   data_event_resources = [
     {
       type   = "AWS::S3::Object"
-      values = ["arn:${data.aws_partition.current.partition}:s3"]
+      values = ["arn:${data.aws_partition.current.partition}:s3:::"]
     },
     {
       type   = "AWS::Lambda::Function"

--- a/terraform/modules/cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/main.tf
@@ -351,8 +351,19 @@ locals {
     # an SSO user signing in without MFA at the IdP would not surface here.
     # Drop the type constraint and let the alarm fire on any successful
     # console sign-in that lacks MFAUsed=Yes.
+    #
+    # SSO/IAM Identity Center caveat (PR #13 codex P2): for federated
+    # AssumedRole sessions, CloudTrail often omits
+    # `additionalEventData.MFAUsed` even when the IdP enforced MFA, which
+    # would produce false positives. Cross-check
+    # `userIdentity.sessionContext.attributes.mfaAuthenticated` — when
+    # the role was assumed from an MFA-authenticated session this is
+    # "true", and the alarm should not fire. Both predicates use `!=`,
+    # which CloudWatch metric filters evaluate as true when the field
+    # is missing — so plain IAMUser logins (no sessionContext at all)
+    # still match.
     console_no_mfa = {
-      pattern = "{ ($.eventName = ConsoleLogin) && ($.additionalEventData.MFAUsed != \"Yes\") && ($.responseElements.ConsoleLogin = \"Success\") }"
+      pattern = "{ ($.eventName = ConsoleLogin) && ($.responseElements.ConsoleLogin = \"Success\") && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.sessionContext.attributes.mfaAuthenticated != \"true\") }"
       name    = "ConsoleSignInWithoutMFA"
     }
     kms_key_disable = {

--- a/terraform/modules/cloudtrail/main.tf
+++ b/terraform/modules/cloudtrail/main.tf
@@ -309,6 +309,26 @@ resource "aws_cloudtrail" "this" {
     include_management_events = true
   }
 
+  # Data-event selector(s) — CMMC AU controls (ISS-01).
+  # Only emitted when callers pass a non-empty `data_event_resources` list,
+  # so the demo root stays cost-stripped while govcloud captures S3 + Lambda
+  # data plane activity.
+  dynamic "event_selector" {
+    for_each = length(var.data_event_resources) > 0 ? [1] : []
+    content {
+      read_write_type           = "All"
+      include_management_events = false
+
+      dynamic "data_resource" {
+        for_each = var.data_event_resources
+        content {
+          type   = data_resource.value.type
+          values = data_resource.value.values
+        }
+      }
+    }
+  }
+
   depends_on = [aws_s3_bucket_policy.trail]
 }
 
@@ -325,8 +345,14 @@ locals {
       pattern = "{ ($.eventName = DeleteGroupPolicy) || ($.eventName = DeleteRolePolicy) || ($.eventName = DeleteUserPolicy) || ($.eventName = PutGroupPolicy) || ($.eventName = PutRolePolicy) || ($.eventName = PutUserPolicy) || ($.eventName = CreatePolicy) || ($.eventName = DeletePolicy) || ($.eventName = CreatePolicyVersion) || ($.eventName = DeletePolicyVersion) || ($.eventName = AttachRolePolicy) || ($.eventName = DetachRolePolicy) || ($.eventName = AttachUserPolicy) || ($.eventName = DetachUserPolicy) || ($.eventName = AttachGroupPolicy) || ($.eventName = DetachGroupPolicy) }"
       name    = "IAMPolicyChange"
     }
+    # ConsoleLogin is emitted for both IAMUser and AssumedRole identities
+    # (the latter covers SSO/identity-federation sign-ins). Filtering on
+    # userIdentity.type missed the AssumedRole path entirely (ISS-03), so
+    # an SSO user signing in without MFA at the IdP would not surface here.
+    # Drop the type constraint and let the alarm fire on any successful
+    # console sign-in that lacks MFAUsed=Yes.
     console_no_mfa = {
-      pattern = "{ ($.eventName = ConsoleLogin) && ($.additionalEventData.MFAUsed != \"Yes\") && ($.userIdentity.type = \"IAMUser\") && ($.responseElements.ConsoleLogin = \"Success\") }"
+      pattern = "{ ($.eventName = ConsoleLogin) && ($.additionalEventData.MFAUsed != \"Yes\") && ($.responseElements.ConsoleLogin = \"Success\") }"
       name    = "ConsoleSignInWithoutMFA"
     }
     kms_key_disable = {

--- a/terraform/modules/cloudtrail/variables.tf
+++ b/terraform/modules/cloudtrail/variables.tf
@@ -32,6 +32,24 @@ variable "is_multi_region" {
   default     = true
 }
 
+# CloudTrail data events (CMMC AU controls — closes ISS-01).
+#
+# Management events alone do not record S3 GetObject / PutObject or Lambda
+# Invoke calls. CMMC L2 AU.L2-3.3.1/3.3.2 expect data-plane visibility on
+# CUI stores and CUI-processing functions. Pass a list of objects of the
+# form `{ type = "AWS::S3::Object" | "AWS::Lambda::Function" | ...,
+# values = ["arn:aws-us-gov:s3", "arn:aws-us-gov:s3:::specific-bucket/"] }`.
+# Empty list (default) keeps backward compatibility for the demo root,
+# where data events would add cost without compliance benefit (no CUI).
+variable "data_event_resources" {
+  description = "Data-event resources to record (S3 objects, Lambda functions, etc). Empty disables data events."
+  type = list(object({
+    type   = string
+    values = list(string)
+  }))
+  default = []
+}
+
 variable "tags" {
   description = "Tags applied to all resources."
   type        = map(string)

--- a/terraform/modules/cloudtrail/variables.tf
+++ b/terraform/modules/cloudtrail/variables.tf
@@ -38,7 +38,19 @@ variable "is_multi_region" {
 # Invoke calls. CMMC L2 AU.L2-3.3.1/3.3.2 expect data-plane visibility on
 # CUI stores and CUI-processing functions. Pass a list of objects of the
 # form `{ type = "AWS::S3::Object" | "AWS::Lambda::Function" | ...,
-# values = ["arn:aws-us-gov:s3", "arn:aws-us-gov:s3:::specific-bucket/"] }`.
+# values = [<arn-prefix>, ...] }`.
+#
+# ARN-prefix forms accepted by CloudTrail data-event selectors:
+#   AWS::S3::Object       — `arn:<partition>:s3:::` (all buckets in the
+#                           partition) or `arn:<partition>:s3:::<bucket>/`
+#                           or `arn:<partition>:s3:::<bucket>/<prefix>`.
+#   AWS::Lambda::Function — `arn:<partition>:lambda` (all functions in
+#                           the account) or a specific function ARN
+#                           `arn:<partition>:lambda:<region>:<account>:function:<name>`.
+# CloudTrail does prefix matching on these strings; wildcards are not
+# supported mid-string. Use the explicit triple-colon form for S3 to
+# avoid prefix-collision ambiguity (PR #13 copilot/gemini).
+#
 # Empty list (default) keeps backward compatibility for the demo root,
 # where data events would add cost without compliance benefit (no CUI).
 variable "data_event_resources" {

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -12,6 +12,12 @@ locals {
   private_subnets = [for i, az in local.azs : cidrsubnet(var.cidr_block, 4, i + 4)]
   data_subnets    = [for i, az in local.azs : cidrsubnet(var.cidr_block, 4, i + 8)]
 
+  # Interface endpoints provisioned in every VPC. `xray` is included so
+  # CMMC SI-controls evidence (Lambda tracing) can be delivered without
+  # an internet egress path \u2014 the demo VPC has `enable_nat_gateway = false`
+  # and govcloud enclaves are intentionally egress-isolated. Adding xray
+  # here closes the gap flagged on PR #13 (copilot review on demo Lambda
+  # tracing) without each consumer having to wire it themselves.
   interface_endpoints = toset([
     "ssm",
     "ssmmessages",
@@ -21,6 +27,7 @@ locals {
     "monitoring",
     "sts",
     "ec2",
+    "xray",
   ])
 }
 


### PR DESCRIPTION
## Summary

Closes the residual bot findings from #3 that prior PRs (#4, #5, #6, #7) didn't pick up. Five items, scoped to one commit:

| ID | Severity | File | Fix |
|---|---|---|---|
| **ISS-01** | HIGH | `terraform/modules/cloudtrail/main.tf` + `terraform/govcloud/main.tf` | New `data_event_resources` variable; govcloud sets S3-Object + Lambda-Function ARN-prefix selectors. Demo stays cost-stripped (default `[]`). |
| **ISS-03** | MEDIUM | `terraform/modules/cloudtrail/main.tf` | Drop `userIdentity.type = "IAMUser"` from `ConsoleSignInWithoutMFA` filter so AssumedRole/SSO sign-ins also surface. |
| **ISS-04** | MEDIUM | `terraform/demo/main.tf` | Added `vpc_config` (private subnets + new SG with egress restricted to VPC CIDR), `AWSLambdaVPCAccessExecutionRole`. |
| **ISS-28** | LOW | `terraform/demo/main.tf` | `tracing_config { mode = "Active" }` + `AWSXRayDaemonWriteAccess`. |
| **ISS-15** | CI | `.github/workflows/compliance-checks.yml` | Install puppeteer chromium runtime deps via apt + `--no-sandbox` puppeteer config. |

## Testing

- `terraform fmt -recursive` clean.
- `terraform validate` green: cloudtrail module, demo root, govcloud root.
- `actionlint .github/workflows/compliance-checks.yml` clean.
- `bash test.sh` → **199 pass / 1 warn / 0 fail**.
- `mermaid-lint` exercised by this PR's CI run; expect green.

## Architecture decisions

- **`data_event_resources` defaults empty.** Demo root is intentionally cost-stripped (no CUI present, so no AU.L2-3.3.1/3.3.2 obligation). Govcloud opts in.
- **MFA filter scope.** Removing the `IAMUser` constraint expands signal to AssumedRole/SSO; documented inline. Operators with high SSO volume should treat the alarm threshold as a tunable, not silence the filter.
- **Demo Lambda SG egress = VPC CIDR only.** Mirrors the enclave network model — Lambda reaches AWS APIs through interface endpoints, no NAT/internet path.
- **Mermaid CI fix uses apt + puppeteer config rather than swapping actions.** Smaller diff, no new dependency on a third-party action.

## Doc sync

- [x] No SSP/CSV control changes (data event addition is evidence-strengthening for AU.L2-3.3.1/3.3.2; existing SSP language still matches).
- [x] No new module variables that need README updates beyond inline comments (the variable docstring is the spec).
- [x] `AI_REPO_GUIDE.md` unchanged — no new commands or directory layout.

## Follow-ups (out of scope here)

- USER-09 (CSV `notes` column dual-purpose) — explicitly deferred per #3 triage.
- USER-07 (READMEs) — not reproducible per #3 triage.

Refs #3
