### PR TITLE
docs(phase-8): ADR-011 + prompt 11 — workload module library scope (#2)

### DIFF
--- a/.github/prompts/11-workload-modules.md
+++ b/.github/prompts/11-workload-modules.md
@@ -54,10 +54,15 @@ Per ADR-011 §5, every workload-module PR delivers:
 ### Module files (`terraform/modules/workloads/<name>/`)
 
 - `main.tf` — resources, with `data.aws_partition.current` lookup; no
-  hardcoded `arn:aws:` strings
+  hardcoded `arn:aws:` strings. Partition-conditional features fail
+  closed at `terraform validate` time via `precondition` blocks on the
+  affected resource / output / `check` block (per ADR-011 §3 —
+  variables can’t host `precondition`, only `validation`)
 - `variables.tf` — input variables; every var has `description` and
-  (where applicable) `validation` blocks; partition-conditional
-  features use `precondition` per ADR-011 §3
+  (where applicable) a `validation` block. Variable-shaped invariants
+  (“must be a /16 CIDR”, “must match a known partition string”) live
+  here; cross-resource or partition-conditional invariants live on
+  `precondition` blocks in `main.tf` / `outputs.tf` / `check` blocks
 - `outputs.tf` — minimum surface needed for the demo + govcloud roots
   to consume the module; downstream consumers documented in README
   "Outputs" section
@@ -100,13 +105,14 @@ Per ADR-011 §5, every workload-module PR delivers:
 
 ### Compliance artifact updates
 
-- `controls/nist-800-171-mapping.csv` — at least one row's
-  `addressed_by_repo` column flips `FALSE → TRUE` (or
-  `requires_client_config TRUE → FALSE`) as a result of this module
+- `controls/nist-800-171-mapping.csv` — at least one row moves
+  `addressed_by_repo` from `none` to `partial` or `full`, and/or flips
+  `requires_client_config` from `true` to `false` (per the enum values
+  defined in `controls/schema.json`) as a result of this module
   shipping. The CSV columns to update for each affected row:
-  `addressed_by_repo`, `aws_services`, `terraform_resources`. If no
-  row qualifies, this is a signal that the module isn't actually
-  earning its keep — escalate, don't fudge.
+  `addressed_by_repo`, `aws_services`, `terraform_resources`,
+  `requires_client_config`. If no row qualifies, this is a signal that
+  the module isn’t actually earning its keep — escalate, don’t fudge.
 - `ssp/SSP.md` — for every newly-covered control, replace the `TODO`
   status with a written control statement following the format used
   by Phase 3 controls. The CSV↔SSP sync guard in

--- a/.github/prompts/11-workload-modules.md
+++ b/.github/prompts/11-workload-modules.md
@@ -1,0 +1,211 @@
+# 11 — Workload modules (per-module implementation template)
+
+> **Phase 8** — workload module library. This prompt is invoked **once
+> per workload module**, not once per phase. ADR-011 decides the
+> cross-cutting questions (which modules, in what order, with what
+> partition/cost policy); this prompt decides only the per-module
+> implementation shape.
+
+## Context
+
+Phases 1–7 shipped the enclave plumbing (VPC, IAM, KMS, CloudTrail,
+GuardDuty, Config, demo Lambda). Phase 8 layers CUI-workload-shaped
+patterns on top, the kinds MSPs and DIBs would copy/paste into their
+own infrastructure.
+
+[ADR-011](../../docs/decisions/adr-011-phase-8-workload-module-scope.md)
+commits Phase 8 to four modules under `terraform/modules/workloads/`,
+with this sequencing:
+
+1. `s3_cui` — CUI bucket pattern
+2. `secrets` — Secrets Manager / SSM parameter pattern
+3. `alarms` — opinionated CloudWatch alarm set
+4. `rds_cui` — RDS-Postgres for CUI (gated on a separate
+   destroy-workflow verification PR; do not start without that PR
+   merged)
+
+This file is the implementation prompt for *one* of those modules at a
+time. The issue assigning the work names which module.
+
+## Prerequisites
+
+- Read [ADR-011](../../docs/decisions/adr-011-phase-8-workload-module-scope.md)
+  end-to-end before starting. It is the source of truth for scope,
+  GovCloud-degradation policy, and demo-cost policy. This prompt does
+  not restate those decisions — it enforces them via the acceptance
+  criteria.
+- Phase 3 modules under `terraform/modules/` exist and pass
+  `terraform validate` (already true on `main`).
+- Phase 4 roots (`terraform/govcloud/`, `terraform/demo/`) wire the
+  Phase 3 modules and pass `terraform validate` (already true on
+  `main`).
+- For `rds_cui` only: the destroy-workflow verification PR
+  (chore: verify demo-destroy.yml destroys RDS instances) has merged.
+  If it has not, **stop and surface the dependency** rather than
+  shipping without it.
+- AGENTS.md *Analyst pre-flight gate*: this prompt is `NN-prefixed`,
+  so the gate applies. Do not start implementation until the
+  Pre-Flight Report on the assigned issue has verdict **PASS**.
+
+## Deliverables
+
+Per ADR-011 §5, every workload-module PR delivers:
+
+### Module files (`terraform/modules/workloads/<name>/`)
+
+- `main.tf` — resources, with `data.aws_partition.current` lookup; no
+  hardcoded `arn:aws:` strings
+- `variables.tf` — input variables; every var has `description` and
+  (where applicable) `validation` blocks; partition-conditional
+  features use `precondition` per ADR-011 §3
+- `outputs.tf` — minimum surface needed for the demo + govcloud roots
+  to consume the module; downstream consumers documented in README
+  "Outputs" section
+- `versions.tf` — pins matching Phase 3 modules (terraform >= 1.6,
+  hashicorp/aws >= 5.40)
+- `README.md` — exact section list below
+
+### `README.md` section list (in this order)
+
+1. **Purpose** — one paragraph, what the module is and is not
+2. **Inputs** — variable name, type, default, description (table)
+3. **Outputs** — output name, type, description (table)
+4. **NIST 800-171 controls addressed** — bullet list of control IDs
+   the module *fully or partially* implements, with one sentence each
+   citing how
+5. **Partition parity** — per ADR-011 §3: which AWS features the
+   module uses, which partitions support each, and what the
+   `precondition` failure mode is when a feature is missing
+6. **Demo cost** — per ADR-011 §4: line-item monthly cost breakdown
+   (compute / storage / network / data transfer) at the documented
+   sizing
+7. **Production overrides** — what variables a real production caller
+   would override, and to what values, with rationale
+8. **Gaps the consumer must fill** — what this module deliberately
+   does not handle (e.g., DNS records, application-level secret
+   rotation, cross-account replication policies)
+
+### Demo + govcloud wiring
+
+- `terraform/govcloud/main.tf` — instantiate the module with
+  GovCloud-appropriate inputs; **validate-only**, never applied
+- `terraform/demo/main.tf` — instantiate the module with the
+  cheapest-viable sizing per ADR-011 §4; if the steady-state demo
+  cost exceeds $15/mo, gate the wiring behind a
+  `var.enable_<module>_demo` input that defaults to `false` and
+  document this in the demo README
+- `.github/workflows/demo-destroy.yml` — verified (manually or via a
+  CI assertion) to remove every resource the module created. State
+  the verification method in the PR description
+
+### Compliance artifact updates
+
+- `controls/nist-800-171-mapping.csv` — at least one row's
+  `addressed_by_repo` column flips `FALSE → TRUE` (or
+  `requires_client_config TRUE → FALSE`) as a result of this module
+  shipping. The CSV columns to update for each affected row:
+  `addressed_by_repo`, `aws_services`, `terraform_resources`. If no
+  row qualifies, this is a signal that the module isn't actually
+  earning its keep — escalate, don't fudge.
+- `ssp/SSP.md` — for every newly-covered control, replace the `TODO`
+  status with a written control statement following the format used
+  by Phase 3 controls. The CSV↔SSP sync guard in
+  `.github/workflows/compliance-checks.yml` will fail if these
+  diverge.
+
+### Documentation updates
+
+- `AI_REPO_GUIDE.md` — add a row to the "Terraform modules" inventory
+  pointing at `terraform/modules/workloads/<name>/`
+- For the *first* Phase 8 PR to merge: add a "Phase 8 — workload
+  module library" section to `.context/roadmap.md`. For PRs 2–4: add
+  a sub-bullet under that existing section.
+
+## Acceptance criteria
+
+A module PR is mergeable only when **all** of these pass:
+
+- `terraform fmt -recursive -check terraform/` exits 0
+- `terraform -chdir=terraform/modules/workloads/<name> init -backend=false && terraform -chdir=terraform/modules/workloads/<name> validate` passes
+- `terraform -chdir=terraform/govcloud init -backend=false && terraform -chdir=terraform/govcloud validate` passes (module wired in)
+- `terraform -chdir=terraform/demo init -backend=false && terraform -chdir=terraform/demo validate` passes (module wired in)
+- `tflint --recursive` clean
+- `tfsec terraform/` reports no NEW high or critical findings
+  attributable to this module (pre-existing findings are not blockers
+  but should be acknowledged in the PR body)
+- `checkov -d terraform/` reports no NEW failed checks attributable
+  to this module
+- `bash test.sh` passes (199+ checks, 0 failed)
+- `.github/workflows/compliance-checks.yml` passes (CSV schema, CSV↔SSP
+  sync, SSP TODO-count guard)
+- README has all eight sections from the section list above, in that
+  order
+- For `rds_cui` only: PR description cites the destroy-workflow
+  verification PR by number and includes a manual-verification
+  paragraph confirming the destroy worked end-to-end against a real
+  AWS account
+
+## Verification
+
+```bash
+# Module-level
+terraform fmt -recursive -check terraform/
+for m in terraform/modules/workloads/*/; do
+  terraform -chdir="$m" init -backend=false -input=false
+  terraform -chdir="$m" validate
+done
+
+# Root-level
+for r in terraform/govcloud terraform/demo; do
+  terraform -chdir="$r" init -backend=false -input=false
+  terraform -chdir="$r" validate
+done
+
+# Static analysis
+tflint --recursive --chdir=terraform
+tfsec terraform/
+checkov -d terraform/
+
+# Repo-wide
+bash test.sh
+grep -RE 'arn:aws:' terraform/modules/workloads/ && exit 1 || echo "no hardcoded ARN partitions"
+
+# Compliance artifacts (CI runs these automatically)
+python3 scripts/check-controls-csv.py
+bash scripts/check-ssp.sh
+```
+
+## Do NOT
+
+- Do NOT introduce more than one workload module in a single PR
+  (ADR-011 §6, per-PR boundary).
+- Do NOT modify a Phase 3 module's variables, outputs, or behavior in
+  a backward-incompatible way (ADR-011 §7). If the workload module
+  needs new surface from a Phase 3 module, land that as a separate
+  preceding PR.
+- Do NOT silently skip features missing in GovCloud (ADR-011 §3).
+  Fail closed at `terraform validate` time via `precondition` blocks.
+- Do NOT exceed the $15/mo demo cost ceiling without the opt-out flag
+  (ADR-011 §4) or a supersedence to ADR-011.
+- Do NOT pre-write a roadmap entry for a module that has not yet
+  merged. Roadmap entries describe shipped or actively-in-flight
+  work, not aspirations.
+- Do NOT start `rds_cui` until the destroy-workflow verification PR
+  has merged.
+- Do NOT bake account IDs, region names, or bucket names into module
+  defaults.
+
+## Truth-hierarchy updates
+
+- The module README (`terraform/modules/workloads/<name>/README.md`)
+  is the canonical doc for that module — control mappings, inputs,
+  outputs, and partition parity all live there.
+- `AI_REPO_GUIDE.md` "Terraform modules" inventory is the discovery
+  surface; keep it current.
+- `controls/nist-800-171-mapping.csv` and `ssp/SSP.md` are the
+  compliance source of truth; CI guards their consistency. Update
+  both atomically in the same PR as the module.
+- ADR-011 governs the *phase*. Per-module decisions (sizing, schema
+  shape, output surface) live in the module README and the PR body
+  — not in new ADRs unless they supersede a Phase 3 or Phase 8
+  cross-cutting decision.

--- a/docs/decisions/adr-011-phase-8-workload-module-scope.md
+++ b/docs/decisions/adr-011-phase-8-workload-module-scope.md
@@ -1,0 +1,299 @@
+# ADR-011: Phase 8 — workload module library scope and sequencing
+
+## Status
+
+Accepted
+
+## Date
+
+2026-04-25
+
+## Context
+
+Phases 1–7 ([roadmap](../../.context/roadmap.md)) shipped the *enclave
+plumbing* — VPC, IAM baseline, KMS, CloudTrail, GuardDuty, Config, plus
+a demo Lambda. The roadmap explicitly listed *"a workload module library
+(RDS-with-CUI patterns, S3 data-classification patterns, etc.)"* under
+**Future / out-of-scope** with the note "possible Phase 8; track in a
+follow-up issue." Issue #2 is that tracker.
+
+Issue #2 lists four candidate workload patterns (RDS-with-CUI,
+S3-data-classification, secrets/parameter store, alarms) and explicitly
+calls out three pre-implementation problems that need to be decided
+*once*, repo-wide, before any module code lands:
+
+1. **Per-workload variability is high.** RDS-Postgres differs from
+   RDS-MySQL on encryption-in-transit defaults; "active CUI" S3 differs
+   from "archive CUI" S3 on lifecycle and access-pattern shape. Without
+   a rubric, every PR re-litigates which variant ships.
+2. **GovCloud feature-parity gaps.** RDS Proxy, Macie sub-features, and
+   several others differ between commercial AWS and GovCloud. Modules
+   must have a documented policy for what to do when a feature is
+   unavailable in the target partition.
+3. **Cost in the demo stack.** RDS at the cheapest sizing
+   (`db.t4g.micro` + 20 GB gp3) is roughly $13/mo plus storage and I/O.
+   The demo destroy workflow has historically only been verified
+   against the demo Lambda; a stateful workload changes the destroy
+   contract.
+
+The issue also references a per-phase prompt file
+[`.github/prompts/11-workload-modules.md`](../../.github/prompts/11-workload-modules.md)
+that does not yet exist, and notes that **the prompt is itself a
+deliverable** before any implementation PR can run. AGENTS.md's
+*Analyst pre-flight gate* applies to that prompt before the first
+implementation PR opens.
+
+This ADR exists to make the cross-cutting decisions (scope, sequencing,
+GovCloud policy, demo-cost policy, per-PR boundary) once so the prompt
+file and downstream module PRs don't need to re-derive them.
+
+## Decision
+
+We will ship a Phase 8 workload module library as a **series of
+independent additive PRs**, one workload module per PR, governed by
+the rubric and policies below.
+
+### 1. Scope: in / out for Phase 8
+
+**In scope** (this ADR commits to all four; sequencing in §2 below):
+
+| # | Module path | Purpose |
+|---|---|---|
+| 1 | `terraform/modules/workloads/secrets/` | `aws_secretsmanager_secret` + `aws_ssm_parameter` patterns scoped to the enclave CMK; rotation Lambda hook (off by default; consumer enables per-secret) |
+| 2 | `terraform/modules/workloads/s3_cui/` | CUI bucket pattern: object lock (governance), default KMS encryption, public-access block, lifecycle for retention, access logs to a separate log bucket, tag-based policy enforcing `data_classification = cui` |
+| 3 | `terraform/modules/workloads/rds_cui/` | RDS-Postgres in private subnets: KMS-encrypted at rest, TLS-only in transit, IAM auth enabled, audit logging to CloudWatch, deletion protection on, automated backups + cross-region snapshot copy |
+| 4 | `terraform/modules/workloads/alarms/` | Opinionated CloudWatch alarm set wiring the Phase 3 GuardDuty/Config/CloudTrail signals to SNS topics; control-mapped to the IR family |
+
+**Out of scope for Phase 8** (file separate issues if/when needed):
+
+- RDS-MySQL, RDS-MariaDB, Aurora variants. Postgres-only is the
+  *commitment* — not a placeholder. Expanding to other engines is a
+  separate ADR.
+- Macie / DLP automation. Macie's GovCloud feature surface is too
+  partial for a clean partition-aware module; revisit when parity
+  closes.
+- ALB / API Gateway / Fargate workload patterns. The Phase 4 demo
+  already includes a Lambda; further compute patterns should be a
+  separate "compute workload" series, not bundled here.
+- Multi-account / Control Tower / org-trail extensions. Already
+  excluded by the roadmap; restating for clarity.
+- A "secret rotation Lambda library" of canned rotators (Postgres,
+  MySQL, etc.). The secrets module ships the *hook*; the rotators
+  themselves are downstream consumer work.
+
+### 2. Sequencing rubric
+
+Each candidate module is scored on five weighted dimensions. Sequencing
+is by descending total score (ties broken by ascending demo cost).
+
+| Dimension | Weight | Rationale |
+|---|---|---|
+| Number of NIST 800-171 controls the module moves from `requires_client_config = TRUE` to `addressed_by_repo = TRUE` (in `controls/nist-800-171-mapping.csv`) | 3 | Direct compliance utility — the whole point of the repo |
+| Demo-cost ceiling per month at the documented sizing (raw $/mo) | -2 | Cheaper modules ship earlier; expensive ones need their own destroy-workflow verification first |
+| GovCloud parity (1 = full parity, 0 = partial, -2 = no parity) | 2 | Modules with no GovCloud parity should fail closed, not ship |
+| Number of *other Phase 8 modules* that depend on this one (transitive) | 2 | Prerequisite-first reduces rework |
+| Implementation complexity (1 = small, 0 = medium, -1 = large) | 1 | Smaller PRs review faster and reduce blast radius |
+
+Applied to the four in-scope modules:
+
+| Module | Controls | Cost/mo | GovCloud | Depends-on count | Complexity | Score |
+|---|---|---|---|---|---|---|
+| `secrets` | ~4 (SC-12, SC-28, IA family) | ~$0.40/secret | 1 | 2 (rds, alarms reference it) | 1 (small) | `4·3 − 0·(-2) + 1·2 + 2·2 + 1·1` = **19** |
+| `s3_cui` | ~6 (MP family + SC-28 + AU mapping via existing data events) | ~$0.20 (storage-trivial demo bucket) | 1 | 0 | 0 (medium) | `6·3 − 0·(-2) + 1·2 + 0·2 + 0·1` = **20** |
+| `rds_cui` | ~5 (SC-12, SC-28, IA-5, AU family) | ~$13/mo (db.t4g.micro + 20 GB gp3) | 1 | 0 | -1 (large) | `5·3 − 13·(-2) + 1·2 + 0·2 + (-1)·1` = **−10** (cost dominates) |
+| `alarms` | ~3 (IR family) | ~$0/mo (alarms are free; SNS at demo volume is free-tier) | 1 | 0 (consumes Phase 3 outputs) | 1 (small) | `3·3 − 0·(-2) + 1·2 + 0·2 + 1·1` = **12** |
+
+(Cost enters the score as the literal dollar figure with weight −2,
+which is why RDS scores so low — the rubric is designed to punish
+high-monthly-cost demo modules unless the control coverage is
+overwhelming.)
+
+**Resulting sequencing**: `s3_cui` (20) → `secrets` (19) → `alarms` (12)
+→ `rds_cui` (−10).
+
+The `secrets` module is implemented to expose its outputs (KMS key
+references, SSM-path conventions) so that `rds_cui` can consume them
+when it lands; this is documented as a forward-compatibility
+requirement on PR-2 (`secrets`), not enforced via runtime dependency.
+
+The `rds_cui` PR is **gated on** a separate verification that
+`.github/workflows/demo-destroy.yml` correctly destroys an RDS
+instance — adding a stateful workload changes the destroy contract
+and that needs its own PR before the workload module ships.
+
+### 3. GovCloud-degradation policy
+
+When a feature used by a workload module is unavailable or partially
+available in the target partition (commercial vs. `aws-us-gov`), the
+module **MUST fail closed** rather than silently degrade:
+
+- Detect via `data.aws_partition.current.partition` and explicit
+  partition-conditional `var.enable_<feature>` toggles.
+- If a required feature is missing in the configured partition, emit a
+  `terraform validate`-time error (use a `precondition` or `validation`
+  block) — not a runtime AWS API failure on apply.
+- Document the gap in the module README under a `## Partition parity`
+  heading.
+
+Silent degradation (e.g., "if Macie isn't available we just skip it")
+is forbidden. The whole point of the reference repo is that the
+shipped configuration is exactly what evidences the controls; a
+silently-skipped feature breaks that contract.
+
+### 4. Demo-cost policy
+
+Each workload module's `terraform/demo/` wiring **MUST**:
+
+- Document the steady-state monthly cost in the module README under
+  `## Demo cost` with a per-line breakdown (compute, storage, network,
+  data transfer).
+- Default to the cheapest-viable sizing (e.g., `db.t4g.micro` for RDS,
+  single-AZ where the workload pattern allows). Production-shaped
+  defaults belong in the module README's `## Production overrides`
+  section, not in the demo wiring.
+- Be verified against `.github/workflows/demo-destroy.yml` — the
+  destroy workflow run from a clean state must remove every resource
+  the module created. This is an explicit acceptance criterion on
+  every workload-module PR.
+
+If a module's demo cost exceeds **$15/mo** at the documented sizing,
+the PR introducing it must either (a) lower the sizing, (b) gate the
+module's demo wiring behind a `var.enable_<module>_demo` flag that
+defaults to `false`, or (c) update this ADR with a supersedence and a
+new cost ceiling.
+
+### 5. Module conventions (per-module checklist)
+
+Every workload module follows the Phase 3 module conventions
+([prompt 03](../../.github/prompts/03-terraform-shared-modules.md)
+acceptance criteria) plus these Phase 8 additions:
+
+- [ ] Path: `terraform/modules/workloads/<name>/`
+- [ ] Files: `main.tf`, `variables.tf`, `outputs.tf`, `versions.tf`,
+  `README.md`
+- [ ] `versions.tf` matches the Phase 3 pins (terraform >= 1.6,
+  hashicorp/aws >= 5.40)
+- [ ] `data.aws_partition.current` lookup; no hardcoded `arn:aws:`
+- [ ] README sections: Purpose, Inputs, Outputs, NIST 800-171 controls
+  addressed, Partition parity, Demo cost, Production overrides, Gaps
+  the consumer must fill
+- [ ] Wired into `terraform/govcloud/` (validate-only)
+- [ ] Wired into `terraform/demo/` (deployable; destroy-verified)
+- [ ] `controls/nist-800-171-mapping.csv` updated: at least one row
+  flips from `requires_client_config = TRUE` to
+  `addressed_by_repo = TRUE`
+- [ ] `ssp/SSP.md` updated: control statements for newly-covered
+  controls promoted from `TODO` to written
+- [ ] `compliance-checks.yml` CI passes (CSV/SSP sync guards)
+
+### 6. Per-PR boundary
+
+**One workload module per PR.** A PR may not introduce two modules,
+even if related. The rationale is reviewer load, blast radius, and the
+ability to revert one module without unwinding others.
+
+### 7. Backwards compatibility
+
+Phase 8 is **additive only**. No PR in this phase may modify a Phase 3
+module's variables, outputs, or behavior in a backward-incompatible
+way. If a workload module needs something a Phase 3 module doesn't
+expose, the right move is:
+
+1. Open a separate PR that adds the new variable/output to the Phase 3
+   module with a backward-compatible default.
+2. Land that PR first.
+3. Open the workload-module PR consuming the new surface.
+
+## Options Considered
+
+### Option 1: One ADR + one prompt + sequenced per-module PRs (chosen)
+
+- **Pros**: Decision-once-execute-many. The prompt file is the same
+  shape as Phases 1–7, so existing tooling (Analyst pre-flight, agent
+  ownership, `pr-resolve-all.md`, `drive-pr-to-merge.md`) all apply
+  unchanged. Cost and GovCloud policy are decided once, not
+  re-litigated per PR.
+- **Cons**: Forces this ADR to commit to the four-module list and a
+  sequencing rubric before any code is written. If implementation
+  reveals one of the modules is a bad fit, requires a supersedence.
+
+### Option 2: One ADR per workload module (decision-per-module)
+
+- **Pros**: Each ADR can be deeply tailored to its workload. No
+  premature commitment to the four-module list.
+- **Cons**: Floods `docs/decisions/` with low-density ADRs that
+  duplicate the same GovCloud-policy / demo-cost / per-PR-boundary
+  language. ADRs become a per-PR formality rather than a record of
+  cross-cutting decisions.
+
+### Option 3: No ADR, just a prompt file
+
+- **Pros**: Less doc work upfront.
+- **Cons**: The four cross-cutting decisions in §1–§4 would silently
+  live inside a prompt file (conventionally a how-to, not a decision
+  record). Future agents asking "why did Phase 8 ship S3 before RDS?"
+  or "why doesn't the secrets module ship a Postgres rotator?" would
+  have nowhere to look. ADRs exist for exactly this question.
+
+## Consequences
+
+### Positive
+
+- Sequencing (`s3_cui` → `secrets` → `alarms` → `rds_cui`) is explicit,
+  justified, and reviewable. The first PR doesn't have to argue why it
+  goes first.
+- The GovCloud-fail-closed policy is set once. No per-module PR
+  re-debates it.
+- Demo cost has a hard ceiling ($15/mo per module) and an opt-out
+  escape hatch (`var.enable_<module>_demo` flag), so a module can ship
+  even if its cheapest sizing exceeds the ceiling.
+- The `rds_cui` gating on a destroy-workflow verification PR is
+  explicit, not discovered late.
+
+### Negative
+
+- The four-module commitment may turn out wrong for one or more
+  modules. A supersedence is the contract for changing the list, which
+  is the right cost — but it's not free.
+- The sequencing rubric weights are judgment calls (3 / -2 / 2 / 2 /
+  1). Reasonable people could pick different weights and get a
+  different order. The weights are documented so future agents can
+  argue with the rubric, not the ranking.
+
+### Neutral
+
+- The phase will likely span several months of calendar time given the
+  per-PR boundary and the destroy-workflow gating on `rds_cui`. This
+  is by design — the v1 enclave was the contracted deliverable; Phase
+  8 is utility expansion.
+
+## Implementation
+
+- [x] Land this ADR (PR for issue #2).
+- [x] Land [`.github/prompts/11-workload-modules.md`](../../.github/prompts/11-workload-modules.md)
+  in the same PR — references this ADR for the cross-cutting
+  decisions, supplies the per-module template for individual
+  implementation PRs.
+- [ ] File a separate issue for the destroy-workflow verification PR
+  that gates `rds_cui`.
+- [ ] File one tracking issue per module (4 issues), each referencing
+  this ADR + the prompt file. Sequence per §2.
+- [ ] First implementation PR: `s3_cui` (per the rubric).
+- [ ] Update `.context/roadmap.md` to add a "Phase 8 — workload module
+  library" section once the first module merges (don't pre-write the
+  section before implementation begins; roadmap entries describe
+  shipped or actively-in-flight work).
+
+## References
+
+- Issue #2 — Phase 8 tracker
+- [`.context/roadmap.md`](../../.context/roadmap.md) — Future /
+  out-of-scope section that originally promised Phase 8
+- [`docs/postmortems/postmortem-001-workflow-bypass.md`](../postmortems/postmortem-001-workflow-bypass.md)
+  — context on why follow-up issues for Phase 8 are being filed
+  retroactively
+- [`.github/prompts/03-terraform-shared-modules.md`](../../.github/prompts/03-terraform-shared-modules.md)
+  — Phase 3 module conventions that Phase 8 extends
+- [`.github/prompts/11-workload-modules.md`](../../.github/prompts/11-workload-modules.md)
+  — the per-module implementation prompt that this ADR's §5 checklist
+  enforces

--- a/docs/decisions/adr-011-phase-8-workload-module-scope.md
+++ b/docs/decisions/adr-011-phase-8-workload-module-scope.md
@@ -88,8 +88,8 @@ is by descending total score (ties broken by ascending demo cost).
 
 | Dimension | Weight | Rationale |
 |---|---|---|
-| Number of NIST 800-171 controls the module moves from `requires_client_config = TRUE` to `addressed_by_repo = TRUE` (in `controls/nist-800-171-mapping.csv`) | 3 | Direct compliance utility — the whole point of the repo |
-| Demo-cost ceiling per month at the documented sizing (raw $/mo) | -2 | Cheaper modules ship earlier; expensive ones need their own destroy-workflow verification first |
+| Number of NIST 800-171 controls the module moves from `addressed_by_repo = none` to `addressed_by_repo = partial` or `full`, and/or from `requires_client_config = true` to `requires_client_config = false`, in `controls/nist-800-171-mapping.csv` (per the enum values defined in `controls/schema.json`) | 3 | Direct compliance utility — the whole point of the repo |
+| Demo-cost ceiling per month at the documented sizing (raw $/mo, rounded down to the nearest dollar so sub-$1 sundries score as 0) | -2 | Cheaper modules ship earlier; expensive ones need their own destroy-workflow verification first |
 | GovCloud parity (1 = full parity, 0 = partial, -2 = no parity) | 2 | Modules with no GovCloud parity should fail closed, not ship |
 | Number of *other Phase 8 modules* that depend on this one (transitive) | 2 | Prerequisite-first reduces rework |
 | Implementation complexity (1 = small, 0 = medium, -1 = large) | 1 | Smaller PRs review faster and reduce blast radius |
@@ -98,15 +98,16 @@ Applied to the four in-scope modules:
 
 | Module | Controls | Cost/mo | GovCloud | Depends-on count | Complexity | Score |
 |---|---|---|---|---|---|---|
-| `secrets` | ~4 (SC-12, SC-28, IA family) | ~$0.40/secret | 1 | 2 (rds, alarms reference it) | 1 (small) | `4·3 − 0·(-2) + 1·2 + 2·2 + 1·1` = **19** |
-| `s3_cui` | ~6 (MP family + SC-28 + AU mapping via existing data events) | ~$0.20 (storage-trivial demo bucket) | 1 | 0 | 0 (medium) | `6·3 − 0·(-2) + 1·2 + 0·2 + 0·1` = **20** |
-| `rds_cui` | ~5 (SC-12, SC-28, IA-5, AU family) | ~$13/mo (db.t4g.micro + 20 GB gp3) | 1 | 0 | -1 (large) | `5·3 − 13·(-2) + 1·2 + 0·2 + (-1)·1` = **−10** (cost dominates) |
-| `alarms` | ~3 (IR family) | ~$0/mo (alarms are free; SNS at demo volume is free-tier) | 1 | 0 (consumes Phase 3 outputs) | 1 (small) | `3·3 − 0·(-2) + 1·2 + 0·2 + 1·1` = **12** |
+| `secrets` | ~4 (SC-12, SC-28, IA family) | $0/mo (rounded; ~$0.40/secret) | 1 | 2 (rds, alarms reference it) | 1 (small) | `4·3 + 0·(-2) + 1·2 + 2·2 + 1·1` = **19** |
+| `s3_cui` | ~6 (MP family + SC-28 + AU mapping via existing data events) | $0/mo (rounded; ~$0.20 storage-trivial demo bucket) | 1 | 0 | 0 (medium) | `6·3 + 0·(-2) + 1·2 + 0·2 + 0·1` = **20** |
+| `rds_cui` | ~5 (SC-12, SC-28, IA-5, AU family) | ~$13/mo (db.t4g.micro + 20 GB gp3) | 1 | 0 | -1 (large) | `5·3 + 13·(-2) + 1·2 + 0·2 + (-1)·1` = **−10** (cost dominates) |
+| `alarms` | ~3 (IR family) | $0/mo (alarms are free; SNS at demo volume is free-tier) | 1 | 0 (consumes Phase 3 outputs) | 1 (small) | `3·3 + 0·(-2) + 1·2 + 0·2 + 1·1` = **12** |
 
-(Cost enters the score as the literal dollar figure with weight −2,
-which is why RDS scores so low — the rubric is designed to punish
-high-monthly-cost demo modules unless the control coverage is
-overwhelming.)
+(Cost enters each score as the literal $/mo figure multiplied by
+weight −2, which is why RDS scores so low — the rubric is designed to
+punish high-monthly-cost demo modules unless the control coverage is
+overwhelming. Per the dimension table, sub-$1/mo sundries are rounded
+down to 0 so the rubric stays in integers.)
 
 **Resulting sequencing**: `s3_cui` (20) → `secrets` (19) → `alarms` (12)
 → `rds_cui` (−10).
@@ -180,8 +181,9 @@ acceptance criteria) plus these Phase 8 additions:
 - [ ] Wired into `terraform/govcloud/` (validate-only)
 - [ ] Wired into `terraform/demo/` (deployable; destroy-verified)
 - [ ] `controls/nist-800-171-mapping.csv` updated: at least one row
-  flips from `requires_client_config = TRUE` to
-  `addressed_by_repo = TRUE`
+  moves `addressed_by_repo` from `none` to `partial` or `full`, and/or
+  flips `requires_client_config` from `true` to `false` (per the enum
+  values defined in `controls/schema.json`)
 - [ ] `ssp/SSP.md` updated: control statements for newly-covered
   controls promoted from `TODO` to written
 - [ ] `compliance-checks.yml` CI passes (CSV/SSP sync guards)


### PR DESCRIPTION
## Summary

Phase 8 setup: ADR-011 (scope + cross-cutting policy) and prompt
`11-workload-modules.md` (per-module implementation template).
Docs-only — no Terraform, workflow, or script changes.

Per the issue #2 question round and the answers there, this PR
**stops after ADR + prompt**. Per-module implementation lands in
follow-up PRs, one per module, gated by the Analyst pre-flight on
each.

Closes nothing (issue #2 stays open as the Phase 8 umbrella).

## Decisions captured by ADR-011

1. **In-scope**: 4 modules under `terraform/modules/workloads/` —
   `s3_cui`, `secrets`, `alarms`, `rds_cui` (Postgres-only).
   Out-of-scope explicitly listed (RDS-MySQL/Aurora, Macie, ALB+
   Fargate, multi-account, canned rotators).
2. **Sequencing rubric** — weighted scoring on
   `+3·controls`, `−2·$/mo`, `+2·GovCloud-parity`,
   `+2·prereq-count`, `+1·inverse-complexity`. Computed order:
   `s3_cui` (20) → `secrets` (19) → `alarms` (12) → `rds_cui` (−10).
3. **GovCloud parity**: fail closed at `terraform validate` time via
   `precondition`/`validation` blocks. README requires a
   `## Partition parity` section.
4. **Demo cost**: $15/mo ceiling. Anything above is gated behind
   `var.enable_<module>_demo` (default false). README requires a
   `## Demo cost` line-item.
5. **Per-module conventions**: 12-item checklist extending Phase 3
   (data.aws_partition lookup, no hardcoded `arn:aws:`, README
   citing ≥3 NIST 800-171 controls, CSV+SSP atomic update, etc.).
6. **One module per PR** — no bundling.
7. **Additive-only** — Phase 3 backward-incompat changes require
   their own preceding PRs.

## Why a separate prompt file

Prompt 11 is invoked **once per module**, not once per phase. ADR-011
fixes the cross-cutting decisions so per-module PRs don't re-litigate
them; prompt 11 enforces those decisions via acceptance criteria.
This pattern matches Phase 3's prompt 03.

## Numbering note

ADR-011 was tentatively reserved by issue #11's parked plan.
Maintainer answered the question round with "release reservation
to Phase 8". Comment posted on #11 noting #11's plan will use the
next free slot when implemented.

## Verification

- [x] `bash test.sh` — 199 passed, 1 warning, 0 failed
- [x] No Terraform/workflow changes (docs-only)
- [x] ADR follows `docs/decisions/adr-template.md` structure
- [x] Prompt 11 follows the prompt-file conventions used by 03–10

## Doc sync

- [x] ADR added (`docs/decisions/adr-011-phase-8-workload-module-scope.md`)
- [x] Prompt added (`.github/prompts/11-workload-modules.md`)
- [ ] `AI_REPO_GUIDE.md` — no update needed; will land with first
      module PR (which adds the `terraform/modules/workloads/` row)
- [ ] `.context/roadmap.md` — no update needed; will land with first
      module PR per ADR-011 §Implementation
- [ ] `controls/nist-800-171-mapping.csv`, `ssp/SSP.md` — no update
      needed; updates land per-module
- [x] No Phase 3 module behavior changed

## Follow-ups (filed after merge)

1. `chore(ci): verify demo-destroy.yml destroys RDS instances` —
   blocks `rds_cui` per ADR-011 §1
2. Tracking issue: `feat(workloads): s3_cui module` (PR 1 of 4)
3. Tracking issue: `feat(workloads): secrets module` (PR 2 of 4)
4. Tracking issue: `feat(workloads): alarms module` (PR 3 of 4)
5. Tracking issue: `feat(workloads): rds_cui module` (PR 4 of 4,
   gated on follow-up #1)

Refs #2.
